### PR TITLE
Pull out confusing stuff with logger and try/excepts in eventhub

### DIFF
--- a/aio_azure_clients_toolbox/clients/eventhub.py
+++ b/aio_azure_clients_toolbox/clients/eventhub.py
@@ -293,6 +293,7 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
             except (AuthenticationError, ClientClosedError, ConnectionLostError, ConnectError):
                 logger.error(f"Error sending event: {event}")
                 logger.error(f"{traceback.format_exc()}")
+                # Mark this connection closed so it won't be reused
                 await conn.close()
                 raise
             return event_data_batch
@@ -327,6 +328,7 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
                 return event_data_batch
             except (AuthenticationError, ClientClosedError, ConnectionLostError, ConnectError):
                 logger.error(f"Error sending event: {traceback.format_exc()}")
+                # Mark this connection closed so it won't be reused
                 await conn.close()
                 raise
 
@@ -346,6 +348,7 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
                 return event_data_batch
             except (AuthenticationError, ClientClosedError, ConnectionLostError, ConnectError):
                 logger.error(f"Error sending batch {traceback.format_exc()}")
+                # Mark this connection closed so it won't be reused
                 await conn.close()
                 raise
 

--- a/aio_azure_clients_toolbox/clients/eventhub.py
+++ b/aio_azure_clients_toolbox/clients/eventhub.py
@@ -62,7 +62,6 @@ class Eventhub:
         self,
         event: EventData,
         partition_key: str | None = None,
-        log=None,
     ):
         """
         Send a *single* EventHub event which is already encoded as `EventData`.
@@ -79,15 +78,8 @@ class Eventhub:
         # Add events to the batch.
         event_data_batch.add(event)
 
-        try:
-            # Send the batch of events to the event hub.
-            await self.client.send_batch(event_data_batch)
-        except ValueError:  # Size exceeds limit. This shouldn't happen if you make sure before hand.
-            if log is not None:
-                log.error("Eventhub Size of the event data list exceeds the size limit of a single send")
-        except EventHubError as eh_err:
-            if log is not None:
-                log.error("Eventhub Sending error: ", eh_err)
+        # Send the batch of events to the event hub.
+        await self.client.send_batch(event_data_batch)
 
         return event_data_batch
 
@@ -95,7 +87,6 @@ class Eventhub:
         self,
         event: bytes | str,
         partition_key: str | None = None,
-        log=None,
     ):
         """
         Send a *single* EventHub event. See `send_events_batch` for
@@ -113,15 +104,8 @@ class Eventhub:
         # Add events to the batch.
         event_data_batch.add(EventData(event))
 
-        try:
-            # Send the batch of events to the event hub.
-            await self.client.send_batch(event_data_batch)
-        except ValueError:  # Size exceeds limit. This shouldn't happen if you make sure before hand.
-            if log is not None:
-                log.error("Eventhub Size of the event data list exceeds the size limit of a single send")
-        except EventHubError as eh_err:
-            if log is not None:
-                log.error("Eventhub Sending error: ", eh_err)
+        # Send the batch of events to the event hub.
+        await self.client.send_batch(event_data_batch)
 
         return event_data_batch
 
@@ -129,7 +113,6 @@ class Eventhub:
         self,
         events_list: list[bytes | str],
         partition_key: str | None = None,
-        log=None,
     ):
         """
         Sending events in a batch is more performant than sending individual events.
@@ -147,33 +130,18 @@ class Eventhub:
         for event in events_list:
             event_data_batch.add(EventData(event))
 
-        try:
-            # Send the batch of events to the event hub.
-            await self.client.send_batch(event_data_batch)
-        except ValueError:  # Size exceeds limit. This shouldn't happen if you make sure before hand.
-            if log is not None:
-                log.error("Eventhub Size of the event data list exceeds the size limit of a single send")
-        except EventHubError as eh_err:
-            if log is not None:
-                log.error("Eventhub Sending error: ", eh_err)
+        # Send the batch of events to the event hub.
+        await self.client.send_batch(event_data_batch)
 
     async def send_events_data_batch(
         self,
         event_data_batch: EventDataBatch,
-        log=None,
     ):
         """
         Sending events in a batch is more performant than sending individual events.
         """
-        try:
-            # Send the batch of events to the event hub.
-            await self.client.send_batch(event_data_batch)
-        except ValueError:  # Size exceeds limit. This shouldn't happen if you make sure before hand.
-            if log is not None:
-                log.error("Eventhub Size of the event data list exceeds the size limit of a single send")
-        except EventHubError as eh_err:
-            if log is not None:
-                log.error("Eventhub Sending error: ", eh_err)
+        # Send the batch of events to the event hub.
+        await self.client.send_batch(event_data_batch)
 
 
 class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
@@ -220,7 +188,7 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
         self.ready_message = ready_message
 
     def __getattr__(self, key):
-        return getattr
+        return getattr(self.pool, key)
 
     async def create(self):
         """Creates a new connection for our pool"""
@@ -262,7 +230,6 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
         self,
         event: EventData,
         partition_key: str | None = None,
-        log=None,
     ):
         """
         Send a *single* EventHub event which is already encoded as `EventData`.
@@ -280,17 +247,9 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
             # Add events to the batch.
             event_data_batch.add(event)
 
-            try:
-                logger.debug("Sending eventhub batch")
-                # Send the batch of events to the event hub.
-                await conn.send_batch(event_data_batch)
-            except ValueError:  # Size exceeds limit. This shouldn't happen if you make sure before hand.
-                if log is not None:
-                    log.error("Eventhub Size of the event data list exceeds the size limit of a single send")
-            except EventHubError as eh_err:
-                if log is not None:
-                    log.error("Eventhub Sending error: ", eh_err)
-
+            logger.debug("Sending eventhub batch")
+            # Send the batch of events to the event hub.
+            await conn.send_batch(event_data_batch)
             return event_data_batch
 
     @connection_pooling.send_time_deco(logger, "Eventhub.send_event")
@@ -298,7 +257,6 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
         self,
         event: bytes | str,
         partition_key: str | None = None,
-        log=None,
     ):
         """
         Send a *single* EventHub event. See `send_events_batch` for
@@ -317,16 +275,9 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
             # Add events to the batch.
             event_data_batch.add(EventData(event))
 
-            try:
-                logger.debug("Sending eventhub batch")
-                # Send the batch of events to the event hub.
-                await conn.send_batch(event_data_batch)
-            except ValueError:  # Size exceeds limit. This shouldn't happen if you make sure before hand.
-                if log is not None:
-                    log.error("Eventhub Size of the event data list exceeds the size limit of a single send")
-            except EventHubError as eh_err:
-                if log is not None:
-                    log.error("Eventhub Sending error: ", eh_err)
+            logger.debug("Sending eventhub batch")
+            # Send the batch of events to the event hub.
+            await conn.send_batch(event_data_batch)
 
             return event_data_batch
 
@@ -335,7 +286,6 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
         self,
         events_list: list[bytes | str],
         partition_key: str | None = None,
-        log=None,
     ):
         """
         Sending events in a batch is more performant than sending individual events.
@@ -354,34 +304,22 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
             for event in events_list:
                 event_data_batch.add(EventData(event))
 
-            try:
-                logger.debug("Sending eventhub batch")
-                # Send the batch of events to the event hub.
-                await conn.send_batch(event_data_batch)
-            except ValueError:  # Size exceeds limit. This shouldn't happen if you make sure before hand.
-                if log is not None:
-                    log.error("Eventhub Size of the event data list exceeds the size limit of a single send")
-            except EventHubError as eh_err:
-                if log is not None:
-                    log.error("Eventhub Sending error: ", eh_err)
+            logger.debug("Sending eventhub batch")
+            # Send the batch of events to the event hub.
+            await conn.send_batch(event_data_batch)
+            return event_data_batch
 
     @connection_pooling.send_time_deco(logger, "Eventhub.send_events_data_batch")
     async def send_events_data_batch(
         self,
         event_data_batch: EventDataBatch,
-        log=None,
     ):
         """
         Sending events in a batch is more performant than sending individual events.
         """
         async with self.pool.get() as conn:
-            try:
-                logger.debug("Sending eventhub batch")
-                # Send the batch of events to the event hub.
-                await conn.send_batch(event_data_batch)
-            except ValueError:  # Size exceeds limit. This shouldn't happen if you make sure before hand.
-                if log is not None:
-                    log.error("Eventhub Size of the event data list exceeds the size limit of a single send")
-            except EventHubError as eh_err:
-                if log is not None:
-                    log.error("Eventhub Sending error: ", eh_err)
+            logger.debug("Sending eventhub batch")
+            # Send the batch of events to the event hub.
+            await conn.send_batch(event_data_batch)
+            return event_data_batch
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aio-azure-clients-toolbox"
-version = "0.1.0"
+version = "0.2.0"
 description = "Async Azure Clients Mulligan Python projects"
 authors = [
     { "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" },

--- a/tests/clients/test_eventhub.py
+++ b/tests/clients/test_eventhub.py
@@ -2,11 +2,26 @@ from unittest import mock
 
 import pytest
 from aio_azure_clients_toolbox.clients import eventhub
+from azure.eventhub import EventData, EventDataBatch
+from azure.eventhub.exceptions import ClientClosedError
+
+# Three calls to send a ready message
+READY_MESSAGE_METHOD_CALLS = ["create_batch", "add", "send"]
+READY_MESSAGE_CALL_COUNT = len(READY_MESSAGE_METHOD_CALLS)
 
 
 @pytest.fixture()
 def ehub(mockehub):
     return eventhub.Eventhub(
+        "namespace_url.example.net",
+        "name",
+        mock.AsyncMock(),  # credential
+    )
+
+
+@pytest.fixture()
+def managed_ehub(mockehub):
+    return eventhub.ManagedAzureEventhubProducer(
         "namespace_url.example.net",
         "name",
         mock.AsyncMock(),  # credential
@@ -34,6 +49,125 @@ async def test_evhub_send_event(ehub):
     assert len(ehub._client.method_calls) == 3
 
 
+async def test_evhub_send_event_data(ehub):
+    data = EventData(body=b"test")
+    await ehub.send_event_data(data)
+    assert len(ehub._client.method_calls) == 3
+
+
 async def test_evhub_send_event_batch(ehub):
     await ehub.send_events_batch(["test1", "test2"])
     assert len(ehub._client.method_calls) == 4
+
+
+async def test_evhub_send_events_data_batch(ehub):
+    batch = EventDataBatch()
+    batch.add(EventData(body=b"test1"))
+    batch.add(EventData(body=b"test2"))
+
+    await ehub.send_events_data_batch(batch)
+    assert len(ehub._client.method_calls) == 1
+
+
+# # # # # # # # # # # # # # # # # #
+# ---**--> Managed Client <--**---
+# # # # # # # # # # # # # # # # # #
+
+
+async def test_managed_get_create(managed_ehub, mockehub):
+    assert await managed_ehub.create() == mockehub
+
+
+async def test_managed_close(managed_ehub):
+    # set up
+    async with managed_ehub.pool.get() as _conn1:
+        async with managed_ehub.pool.get() as _conn2:
+            pass
+        assert managed_ehub.pool.ready_connection_count == 2
+    await managed_ehub.close()
+    assert managed_ehub.pool.ready_connection_count == 0
+
+
+def get_mock_connection_from_pool(pool):
+    # This is expected to be a mock thing buried in here
+    return pool._pool[0]._connection
+
+
+@pytest.fixture(params=[False, True])
+def mockehub_throwing(request, mockehub):
+    if request.param:
+        # We need the *first* (readiness) call to succeed, and the second to fail
+        mockehub.send_batch.side_effect = [None, ClientClosedError("test")]
+    return (mockehub, request.param)
+
+
+async def test_managed_evhub_send_event(mockehub_throwing, managed_ehub):
+    _mockehub, should_throw = mockehub_throwing
+    expect_call_count = READY_MESSAGE_CALL_COUNT + 3
+    if should_throw:
+        with pytest.raises(ClientClosedError):
+            await managed_ehub.send_event("test")
+        # Connection should be closed
+        assert managed_ehub.pool.ready_connection_count == 0
+        expect_call_count += 1  # for the close
+    else:
+        await managed_ehub.send_event("test")
+        assert (
+            len(get_mock_connection_from_pool(managed_ehub.pool).method_calls)
+            == expect_call_count
+        )
+
+
+async def test_managed_evhub_send_event_data(mockehub_throwing, managed_ehub):
+    _mockehub, should_throw = mockehub_throwing
+    data = EventData(body=b"test")
+    expect_call_count = READY_MESSAGE_CALL_COUNT + 3
+    if should_throw:
+        with pytest.raises(ClientClosedError):
+            await managed_ehub.send_event_data(data)
+        # Connection should be closed
+        assert managed_ehub.pool.ready_connection_count == 0
+        expect_call_count += 1  # for the close
+    else:
+        await managed_ehub.send_event_data(data)
+        assert (
+            len(get_mock_connection_from_pool(managed_ehub.pool).method_calls)
+            == expect_call_count
+        )
+
+
+async def test_managed_evhub_send_event_batch(mockehub_throwing, managed_ehub):
+    _mockehub, should_throw = mockehub_throwing
+    expect_call_count = READY_MESSAGE_CALL_COUNT + 4
+
+    if should_throw:
+        with pytest.raises(ClientClosedError):
+            await managed_ehub.send_events_batch(["test1", "test2"])
+        assert managed_ehub.pool.ready_connection_count == 0
+        expect_call_count += 1  # for the close
+
+    else:
+        await managed_ehub.send_events_batch(["test1", "test2"])
+        assert (
+            len(get_mock_connection_from_pool(managed_ehub.pool).method_calls)
+            == expect_call_count
+        )
+
+
+async def test_managed_evhub_send_events_data_batch(mockehub_throwing, managed_ehub):
+    batch = EventDataBatch()
+    batch.add(EventData(body=b"test1"))
+    batch.add(EventData(body=b"test2"))
+    _mockehub, should_throw = mockehub_throwing
+    expect_call_count = READY_MESSAGE_CALL_COUNT + 1
+    if should_throw:
+        with pytest.raises(ClientClosedError):
+            await managed_ehub.send_events_data_batch(batch)
+        assert managed_ehub.pool.ready_connection_count == 0
+        expect_call_count += 1 # for the close
+    else:
+        await managed_ehub.send_events_data_batch(batch)
+        assert (
+            len(get_mock_connection_from_pool(managed_ehub.pool).method_calls)
+            == expect_call_count
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "aio-azure-clients-toolbox"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -496,7 +496,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/65/13d9e76ca19b0ba5603d71ac8424b5694415b348e719db277b5edc985ff5/cryptography-44.0.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:761817a3377ef15ac23cd7834715081791d4ec77f9297ee694ca1ee9c2c7e5eb", size = 3915420 },
     { url = "https://files.pythonhosted.org/packages/b1/07/40fe09ce96b91fc9276a9ad272832ead0fddedcba87f1190372af8e3039c/cryptography-44.0.0-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3c672a53c0fb4725a29c303be906d3c1fa99c32f58abe008a82705f9ee96f40b", size = 4154498 },
     { url = "https://files.pythonhosted.org/packages/75/ea/af65619c800ec0a7e4034207aec543acdf248d9bffba0533342d1bd435e1/cryptography-44.0.0-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:4ac4c9f37eba52cb6fbeaf5b59c152ea976726b865bd4cf87883a7e7006cc543", size = 3932569 },
-    { url = "https://files.pythonhosted.org/packages/4e/d5/9cc182bf24c86f542129565976c21301d4ac397e74bf5a16e48241aab8a6/cryptography-44.0.0-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:60eb32934076fa07e4316b7b2742fa52cbb190b42c2df2863dbc4230a0a9b385", size = 4164756 },
     { url = "https://files.pythonhosted.org/packages/c7/af/d1deb0c04d59612e3d5e54203159e284d3e7a6921e565bb0eeb6269bdd8a/cryptography-44.0.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ed3534eb1090483c96178fcb0f8893719d96d5274dfde98aa6add34614e97c8e", size = 4016721 },
     { url = "https://files.pythonhosted.org/packages/bd/69/7ca326c55698d0688db867795134bdfac87136b80ef373aaa42b225d6dd5/cryptography-44.0.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f3f6fdfa89ee2d9d496e2c087cebef9d4fcbb0ad63c40e821b39f74bf48d9c5e", size = 4240915 },
     { url = "https://files.pythonhosted.org/packages/ef/d4/cae11bf68c0f981e0413906c6dd03ae7fa864347ed5fac40021df1ef467c/cryptography-44.0.0-cp37-abi3-win32.whl", hash = "sha256:eb33480f1bad5b78233b0ad3e1b0be21e8ef1da745d8d2aecbb20671658b9053", size = 2757925 },
@@ -507,7 +506,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/c7/c656eb08fd22255d21bc3129625ed9cd5ee305f33752ef2278711b3fa98b/cryptography-44.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c5eb858beed7835e5ad1faba59e865109f3e52b3783b9ac21e7e47dc5554e289", size = 3915417 },
     { url = "https://files.pythonhosted.org/packages/ef/82/72403624f197af0db6bac4e58153bc9ac0e6020e57234115db9596eee85d/cryptography-44.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f53c2c87e0fb4b0c00fa9571082a057e37690a8f12233306161c8f4b819960b7", size = 4155160 },
     { url = "https://files.pythonhosted.org/packages/a2/cd/2f3c440913d4329ade49b146d74f2e9766422e1732613f57097fea61f344/cryptography-44.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:9e6fc8a08e116fb7c7dd1f040074c9d7b51d74a8ea40d4df2fc7aa08b76b9e6c", size = 3932331 },
-    { url = "https://files.pythonhosted.org/packages/31/d9/90409720277f88eb3ab72f9a32bfa54acdd97e94225df699e7713e850bd4/cryptography-44.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9abcc2e083cbe8dde89124a47e5e53ec38751f0d7dfd36801008f316a127d7ba", size = 4165207 },
     { url = "https://files.pythonhosted.org/packages/7f/df/8be88797f0a1cca6e255189a57bb49237402b1880d6e8721690c5603ac23/cryptography-44.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d2436114e46b36d00f8b72ff57e598978b37399d2786fd39793c36c6d5cb1c64", size = 4017372 },
     { url = "https://files.pythonhosted.org/packages/af/36/5ccc376f025a834e72b8e52e18746b927f34e4520487098e283a719c205e/cryptography-44.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a01956ddfa0a6790d594f5b34fc1bfa6098aca434696a03cfdbe469b8ed79285", size = 4239657 },
     { url = "https://files.pythonhosted.org/packages/46/b0/f4f7d0d0bcfbc8dd6296c1449be326d04217c57afb8b2594f017eed95533/cryptography-44.0.0-cp39-abi3-win32.whl", hash = "sha256:eca27345e1214d1b9f9490d200f9db5a874479be914199194e746c893788d417", size = 2758672 },


### PR DESCRIPTION
The `Eventhub` producer clients in this library had some confusing logging going on with exceptions that may have been thrown while publishing Eventhub messages. 

Problematically, these clients may have been **swallowing exceptions!**

This is most likely a holdover from our previous usage of this library with own custom loggers.

We have removed the exception-swallowing behavior and also added a check for disconnected clients, so we can mark these as closed. Lastly, I also added methods on the connection pool to count open connections and to expire a particular connection.

In addition, this PR increases test coverage for the `eventhub` clients (including `Managed`) to 99%.

**Future Work**

For a future PR, consider expiring connections for the following Service Bus exceptions:
- `ServiceBusCommunicationError`
- `ServiceBusAuthorizationError`
- `ServiceBusAuthenticationError`
- `ServiceBusConnectionError`

All of the above imported from `azure.servicebus.exceptions`