### PR TITLE
Add expire_conn for service bus connection failures

### DIFF
--- a/aio_azure_clients_toolbox/clients/service_bus.py
+++ b/aio_azure_clients_toolbox/clients/service_bus.py
@@ -206,8 +206,8 @@ class ManagedAzureServiceBusSender(connection_pooling.AbstractorConnector):
                 ServiceBusAuthenticationError,
                 ServiceBusConnectionError,
             ):
-                logger.error(
-                    f"ServiceBus.send_message failed: {traceback.format_exc()}"
+                logger.exception(
+                    f"ServiceBus.send_message failed. Expiring connection: {traceback.format_exc()}"
                 )
                 await self.pool.expire_conn(conn)
                 raise

--- a/aio_azure_clients_toolbox/testing_utils/fixtures.py
+++ b/aio_azure_clients_toolbox/testing_utils/fixtures.py
@@ -314,6 +314,7 @@ def mockservicebus(monkeysession):  # type: ignore
     )
     mocksb._receiver = receiver_client
     mocksb._sender = sender_client
+    sender_client.schedule_messages = mock.AsyncMock()
 
     return mocksb
 
@@ -321,6 +322,15 @@ def mockservicebus(monkeysession):  # type: ignore
 @pytest.fixture()
 def sbus(mockservicebus):
     return clients.service_bus.AzureServiceBus(
+        "https://sbus.example.com",
+        "fake-queue-name",
+        mock.AsyncMock(),  # fake credential
+    )
+
+
+@pytest.fixture()
+def managed_sbus(mockservicebus):
+    return clients.service_bus.ManagedAzureServiceBusSender(
         "https://sbus.example.com",
         "fake-queue-name",
         mock.AsyncMock(),  # fake credential

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aio-azure-clients-toolbox"
-version = "0.2.0"
+version = "0.2.1"
 description = "Async Azure Clients Mulligan Python projects"
 authors = [
     { "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" },

--- a/tests/clients/test_service_bus.py
+++ b/tests/clients/test_service_bus.py
@@ -1,4 +1,8 @@
 import pytest
+from azure.servicebus.exceptions import (
+    ServiceBusAuthenticationError,
+    ServiceBusConnectionError,
+)
 
 
 def test_validate_settings(sbus):
@@ -35,4 +39,80 @@ async def test_close(sbus):
 
 async def test_send_message(sbus, mockservicebus):
     await sbus.send_message("hey")
+    assert mockservicebus._sender.method_calls
+
+
+# # # # # # # # # # # # # # # # # #
+# ---**--> Managed Client <--**---
+# # # # # # # # # # # # # # # # # #
+async def test_managed_get_receiver(managed_sbus, mockservicebus):
+    receiver = managed_sbus.get_receiver()
+    await receiver.bla()
+    assert mockservicebus._receiver.method_calls
+    assert managed_sbus.get_receiver() is receiver
+
+
+async def test_managed_get_sender(managed_sbus, mockservicebus):
+    sender = managed_sbus.get_sender()
+    await sender.bla()
+    assert mockservicebus._sender.method_calls
+    assert managed_sbus.get_sender() is sender
+
+
+async def test_managed_close(managed_sbus):
+    # Make sure these things are bootstrapped
+    async with managed_sbus.pool.get() as _conn1:
+        async with managed_sbus.pool.get() as _conn2:
+            pass
+        assert managed_sbus.pool.ready_connection_count == 2
+    await managed_sbus.close()
+    assert managed_sbus.pool.ready_connection_count == 0
+
+
+def get_mock_connection_from_pool(pool):
+    # This is expected to be a mock thing buried in here
+    return pool._pool[0]._connection
+
+
+@pytest.fixture(params=[False, True])
+def managed_sbus_throwing(request, mockservicebus):
+    if request.param:
+        # We need the *first* (readiness) call to succeed, and the second to fail
+        mockservicebus._sender.schedule_messages.side_effect = [None, ServiceBusConnectionError()]
+    return (mockservicebus, request.param)
+
+
+async def test_ready_auth_failure(mockservicebus, managed_sbus):
+    mockservicebus._sender.schedule_messages.side_effect = ServiceBusAuthenticationError()
+    with pytest.raises(ServiceBusAuthenticationError):
+        await managed_sbus.ready(await managed_sbus.create())
+
+    assert mockservicebus._sender.schedule_messages.call_count == 1
+
+
+async def test_ready_connect_failure(mockservicebus, managed_sbus):
+    mockservicebus._sender.schedule_messages.side_effect = ServiceBusConnectionError()
+    assert not await managed_sbus.ready(await managed_sbus.create())
+    assert mockservicebus._sender.schedule_messages.call_count == 2
+
+
+async def test_managed_sbus_send_message(managed_sbus_throwing, managed_sbus):
+    mockservicebus, should_throw = managed_sbus_throwing
+    expect_call_count = 2
+    if should_throw:
+        with pytest.raises(ServiceBusConnectionError):
+            await managed_sbus.send_message("test")
+        # Connection should be closed
+        assert managed_sbus.pool.ready_connection_count == 0
+        expect_call_count += 1  # for the close
+    else:
+        await managed_sbus.send_message("test")
+        assert (
+            len(get_mock_connection_from_pool(managed_sbus.pool).method_calls)
+            == expect_call_count
+        )
+
+
+async def test_managed_send_message(managed_sbus, mockservicebus):
+    await managed_sbus.send_message("hey")
     assert mockservicebus._sender.method_calls

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "aio-azure-clients-toolbox"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
In a recent PR (#1), we expired Eventhub connections from the ManagedEventhubProducer if there were connection issues using _those_ connections. At the time, we noted that this work should also be applied for the ServiceBusSender connections as well in that Managed client. 

This PR includes the call to the `ConnectionPool.expire_conn` method when any of the following exceptions are thrown while trying to schedule a message with the connection:

- `ServiceBusCommunicationError`
- `ServiceBusAuthorizationError`
- `ServiceBusAuthenticationError`
- `ServiceBusConnectionError`

All of the above imported from `azure.servicebus.exceptions`. 

It's possible in the future that we will want to amend the list of exceptions that can cause us to expire connections: from reading the docstrings on the exceptions in this module, it seemed like some of the others could also apply. For now, we're using the above.

This test also improves test coverage for the `service_bus` module, including new tests for the `ManagedAzureServiceBusSender` class (no tests covered this class previously).