### PR TITLE
Add async methods for getting sender/receiver

### DIFF
--- a/aio_azure_clients_toolbox/clients/service_bus.py
+++ b/aio_azure_clients_toolbox/clients/service_bus.py
@@ -133,9 +133,8 @@ class AzureServiceBus:
             self._sender_client = None
 
         if self._client is not None:
-            if self._client_is_open:
-                async with self.client_open_close_lock:
-                    await self._client.__aexit__(None, None, None)
+            async with self.client_open_close_lock:
+                await self._client.__aexit__(None, None, None)
 
             self._client = None
 

--- a/tests/clients/test_service_bus.py
+++ b/tests/clients/test_service_bus.py
@@ -26,6 +26,20 @@ async def test_get_sender(sbus, mockservicebus):
     assert sbus.get_sender() is sender
 
 
+async def test_get_receiver_async(sbus, mockservicebus):
+    receiver = await sbus.get_receiver_async()
+    await receiver.bla()
+    assert mockservicebus._receiver.method_calls
+    assert await sbus.get_receiver_async() is receiver
+
+
+async def test_get_sender_async(sbus, mockservicebus):
+    sender = await sbus.get_sender_async()
+    await sender.bla()
+    assert mockservicebus._sender.method_calls
+    assert await sbus.get_sender_async() is sender
+
+
 async def test_close(sbus):
     # Make sure these things are bootstrapped
     sbus.get_receiver()

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "aio-azure-clients-toolbox"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
We started seeing a pretty ugly unformatted exception for azure-identity `DefaultAzureCredential` objects and ServiceBus getting senders or receivers. It looks like this:

```sh
{"event": "Future exception was never retrieved\nfuture: <Future finished exception=ClientConnectionError('Connection lost: SSL shutdown timed out')>", "exc_info": ["<class 'aiohttp.client_exceptions.ClientConnectionError'>", "ClientConnectionError('Connection lost: SSL shutdown timed out')", null], "app": "app-portal", "version": "2.14.0", "span": null, "level": "error", "logger": "asyncio", "timestamp": "2025-05-29 21:25:40"}
TimeoutError: SSL shutdown timed out

The above exception was the direct cause of the following exception:

aiohttp.client_exceptions.ClientConnectionError: Connection lost: SSL shutdown timed out
```

This PR addresses this issue by adding new async methods to pull a ServiceBus receiver and sender which use the credential inside a context manager. We never did this before because we didn't know if the credential object could be reused after closing.

Lastly, we kept the sync methods for `get_receiver` and `get_sender` so that clients could continue to use those.