### PR TITLE
Lower default idle connection timeout for eventhub producer connections

### DIFF
--- a/aio_azure_clients_toolbox/clients/eventhub.py
+++ b/aio_azure_clients_toolbox/clients/eventhub.py
@@ -15,7 +15,7 @@ from azure.identity.aio import DefaultAzureCredential
 from aio_azure_clients_toolbox import connection_pooling
 
 TRANSPORT_PURE_AMQP = "amqp"
-EVENTHUB_SEND_TTL_SECONDS = 400
+EVENTHUB_SEND_TTL_SECONDS = 220
 logger = logging.getLogger(__name__)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aio-azure-clients-toolbox"
-version = "0.4.0"
+version = "0.4.1"
 description = "Async Azure Clients Mulligan Python projects"
 authors = [
     { "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" },


### PR DESCRIPTION
This is to address a common issue that appears in the logs:
```
"Connection closed with error: [b'amqp:connection:forced', b\"The connection was inactive for more than the allowed 240000 milliseconds and is closed by container '...'.\", None]
```