### PR TITLE
Surface Timeout params and Close credentials 

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -56,7 +56,7 @@ jobs:
           hide_complexity: true
           indicators: true
           output: both
-          thresholds: '80 80'
+          thresholds: '92 92'
 
       - name: Add Coverage PR Comment
         uses: marocchino/sticky-pull-request-comment@v2

--- a/aio_azure_clients_toolbox/__init__.py
+++ b/aio_azure_clients_toolbox/__init__.py
@@ -3,3 +3,16 @@ from .clients.cosmos import Cosmos, ManagedCosmos
 from .clients.eventgrid import EventGridClient, EventGridConfig, EventGridTopicConfig
 from .clients.eventhub import Eventhub, ManagedAzureEventhubProducer
 from .clients.service_bus import AzureServiceBus, ManagedAzureServiceBusSender
+
+__all__ = [
+    "AzureBlobStorageClient",
+    "Cosmos",
+    "ManagedCosmos",
+    "EventGridClient",
+    "EventGridConfig",
+    "EventGridTopicConfig",
+    "Eventhub",
+    "ManagedAzureEventhubProducer",
+    "AzureServiceBus",
+    "ManagedAzureServiceBusSender",
+]

--- a/aio_azure_clients_toolbox/clients/cosmos.py
+++ b/aio_azure_clients_toolbox/clients/cosmos.py
@@ -117,7 +117,7 @@ class ConnectionManager:
         try:
             await self.credential.close()
         except Exception as exc:
-            logger.warning("Error closing credential: %s", exc)
+            logger.warning("Error closing Cosmos credential: %s", exc)
 
         self._client = None
         self._database = None

--- a/aio_azure_clients_toolbox/clients/cosmos.py
+++ b/aio_azure_clients_toolbox/clients/cosmos.py
@@ -270,7 +270,7 @@ class ManagedCosmos(connection_pooling.AbstractorConnector):
       max_lifespan_seconds:
         Optional setting which controls how long a connection live before recycling.
       pool_connection_create_timeout:
-        Timeout for acquiring a connection from the pool (default: 10 seconds).
+        Timeout for creating a connection in the pool (default: 10 seconds).
       pool_get_timeout:
         Timeout for getting a connection from the pool (default: 60 seconds).
     """

--- a/aio_azure_clients_toolbox/clients/eventhub.py
+++ b/aio_azure_clients_toolbox/clients/eventhub.py
@@ -171,7 +171,9 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
       max_size:
         Connection pool size (default: 10).
       max_idle_seconds:
-        Maximum duration allowed for an idle connection before recylcing it.
+        Maximum duration allowed for an idle connection before recycling it.
+      max_lifespan_seconds:
+        Optional setting which controls how long a connection lives before recycling.
       ready_message:
         A string representing the first "ready" message sent to establish connection.
     """
@@ -186,6 +188,7 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
         max_size: int = connection_pooling.DEFAULT_MAX_SIZE,
         max_idle_seconds: int = EVENTHUB_SEND_TTL_SECONDS,
         ready_message: str = "Connection established",
+        max_lifespan_seconds: int | None = None,
     ):
         self.eventhub_namespace = eventhub_namespace
         self.eventhub_name = eventhub_name
@@ -196,6 +199,7 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
             client_limit=client_limit,
             max_size=max_size,
             max_idle_seconds=max_idle_seconds,
+            max_lifespan_seconds=max_lifespan_seconds,
         )
         self.ready_message = ready_message
 

--- a/aio_azure_clients_toolbox/clients/eventhub.py
+++ b/aio_azure_clients_toolbox/clients/eventhub.py
@@ -195,7 +195,7 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
       max_lifespan_seconds:
         Optional setting which controls how long a connection lives before recycling.
       pool_connection_create_timeout:
-        Timeout for acquiring a connection from the pool (default: 10 seconds).
+        Timeout for creating a connection in the pool (default: 10 seconds).
       pool_get_timeout:
         Timeout for getting a connection from the pool (default: 60 seconds).
       ready_message:

--- a/aio_azure_clients_toolbox/clients/eventhub.py
+++ b/aio_azure_clients_toolbox/clients/eventhub.py
@@ -233,7 +233,7 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
             "acquire_timeout": pool_connection_create_timeout,
         }
 
-    async def create(self):
+    async def create(self) -> ProducerClientCloseWrapper:
         """Creates a new connection for our pool"""
         client = Eventhub(
             self.eventhub_namespace,

--- a/aio_azure_clients_toolbox/clients/eventhub.py
+++ b/aio_azure_clients_toolbox/clients/eventhub.py
@@ -63,6 +63,10 @@ class Eventhub:
         if self._client is not None:
             await self._client.close()
             self._client = None
+        try:
+            await self.credential.close()
+        except Exception as exc:
+            logger.exception(f"Eventhub credential close failed with {exc}")
 
     async def send_event_data(
         self,
@@ -211,8 +215,7 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
         try:
             await self.credential.close()
         except Exception as exc:
-            logger.exception(f"Credential close failed with {exc}")
-
+            logger.warning(f"Eventhub credential close failed with {exc}")
 
     @connection_pooling.send_time_deco(logger, "Eventhub.ready")
     async def ready(self, conn: EventHubProducerClient) -> bool:

--- a/aio_azure_clients_toolbox/clients/service_bus.py
+++ b/aio_azure_clients_toolbox/clients/service_bus.py
@@ -87,7 +87,7 @@ class AzureServiceBus:
         )
         return self._receiver_client
 
-    def get_sender(self) -> ServiceBusSender:
+    def get_sender(self) -> SendClientCloseWrapper:
         if self._sender_client is not None:
             return self._sender_client
 
@@ -175,7 +175,7 @@ class ManagedAzureServiceBusSender(connection_pooling.AbstractorConnector):
             "acquire_timeout": pool_connection_create_timeout,
         }
 
-    def get_sender(self) -> ServiceBusSender:
+    def get_sender(self) -> SendClientCloseWrapper:
         client = AzureServiceBus(
             self.service_bus_namespace_url,
             self.service_bus_queue_name,
@@ -183,7 +183,7 @@ class ManagedAzureServiceBusSender(connection_pooling.AbstractorConnector):
         )
         return client.get_sender()
 
-    async def create(self) -> ServiceBusSender:
+    async def create(self) -> SendClientCloseWrapper:
         """Creates a new connection for our pool"""
         return self.get_sender()
 
@@ -208,7 +208,7 @@ class ManagedAzureServiceBusSender(connection_pooling.AbstractorConnector):
             logger.warning(f"Credential close failed with {exc}")
 
     @connection_pooling.send_time_deco(logger, "ServiceBus.ready")
-    async def ready(self, conn: ServiceBusSender) -> bool:
+    async def ready(self, conn: SendClientCloseWrapper) -> bool:
         """Establishes readiness for a new connection"""
         message = ServiceBusMessage(self.ready_message)
         now = datetime.datetime.now(tz=datetime.UTC)

--- a/aio_azure_clients_toolbox/clients/service_bus.py
+++ b/aio_azure_clients_toolbox/clients/service_bus.py
@@ -118,6 +118,8 @@ class ManagedAzureServiceBusSender(connection_pooling.AbstractorConnector):
         Connection pool size (default: 10).
       max_idle_seconds:
         Maximum duration allowed for an idle connection before recylcing it.
+      max_lifespan_seconds:
+        Optional setting which controls how long a connection lives before recycling.
       ready_message:
         A string representing the first "ready" message sent to establish connection.
     """
@@ -130,6 +132,7 @@ class ManagedAzureServiceBusSender(connection_pooling.AbstractorConnector):
         client_limit: int = connection_pooling.DEFAULT_SHARED_TRANSPORT_CLIENT_LIMIT,
         max_size: int = connection_pooling.DEFAULT_MAX_SIZE,
         max_idle_seconds: int = SERVICE_BUS_SEND_TTL_SECONDS,
+        max_lifespan_seconds: int | None = None,
         ready_message: str = "Connection established",
     ):
         self.service_bus_namespace_url = service_bus_namespace_url
@@ -140,6 +143,7 @@ class ManagedAzureServiceBusSender(connection_pooling.AbstractorConnector):
             client_limit=client_limit,
             max_size=max_size,
             max_idle_seconds=max_idle_seconds,
+            max_lifespan_seconds=max_lifespan_seconds,
         )
         self.ready_message = ready_message
 

--- a/aio_azure_clients_toolbox/clients/service_bus.py
+++ b/aio_azure_clients_toolbox/clients/service_bus.py
@@ -139,7 +139,7 @@ class ManagedAzureServiceBusSender(connection_pooling.AbstractorConnector):
       max_lifespan_seconds:
         Optional setting which controls how long a connection lives before recycling.
       pool_connection_create_timeout:
-        Timeout for acquiring a connection from the pool (default: 10 seconds).
+       Timeout for creating a connection in the pool (default: 10 seconds).
       pool_get_timeout:
         Timeout for getting a connection from the pool (default: 60 seconds).
       ready_message:

--- a/aio_azure_clients_toolbox/clients/service_bus.py
+++ b/aio_azure_clients_toolbox/clients/service_bus.py
@@ -77,6 +77,11 @@ class AzureServiceBus:
         return self._sender_client
 
     async def close(self):
+        try:
+            await self.credential.close()
+        except Exception as exc:
+            logger.warning(f"ServiceBus credential close failed with {exc}")
+
         if self._receiver_client is not None:
             await self._receiver_client.close()
             self._receiver_client = None

--- a/aio_azure_clients_toolbox/connection_pooling.py
+++ b/aio_azure_clients_toolbox/connection_pooling.py
@@ -464,7 +464,8 @@ class ConnectionPool:
     @asynccontextmanager
     async def get(
         self,
-        timeout=10.0,
+        timeout: int = 60.0,
+        acquire_timeout: int = 10.0,
     ) -> AsyncGenerator[AbstractConnection, None]:
         """
         Pull out an idle connection.
@@ -484,7 +485,7 @@ class ConnectionPool:
         while not connection_reached and total_time < timeout:
             for _conn in heapq.nsmallest(conn_check_n, self._pool):
                 if _conn.available:
-                    async with _conn.acquire(timeout=timeout) as conn:
+                    async with _conn.acquire(timeout=acquire_timeout) as conn:
                         if conn is not None:
                             yield conn
                             connection_reached = True

--- a/docs/clients/cosmos.md
+++ b/docs/clients/cosmos.md
@@ -25,7 +25,9 @@ ManagedCosmos(
     client_limit: int = 100,
     max_size: int = 10,
     max_idle_seconds: int = 30,
-    max_lifespan_seconds: int = 60
+    max_lifespan_seconds: int = 60,
+    pool_connection_create_timeout: int = 10,
+    pool_get_timeout: int = 60
 )
 ```
 
@@ -39,6 +41,8 @@ ManagedCosmos(
 - **max_size**: Connection pool size (default: 10)
 - **max_idle_seconds**: Connection idle timeout (default: 30)
 - **max_lifespan_seconds**: Maximum connection lifetime (default: 60)
+- **pool_connection_create_timeout**: Timeout for creating connections in the pool (default: 10 seconds)
+- **pool_get_timeout**: Timeout for acquiring connections from the pool (default: 60 seconds)
 
 ### Usage Example
 

--- a/docs/clients/eventhub.md
+++ b/docs/clients/eventhub.md
@@ -25,7 +25,9 @@ ManagedAzureEventhubProducer(
     max_size: int = 10,
     max_idle_seconds: int = 300,
     max_lifespan_seconds: int = None,
-    ready_message: str = None
+    ready_message: str = None,
+    pool_connection_create_timeout: int = 10,
+    pool_get_timeout: int = 60
 )
 ```
 
@@ -40,6 +42,8 @@ ManagedAzureEventhubProducer(
 - **max_idle_seconds**: Connection idle timeout
 - **max_lifespan_seconds**: Maximum connection lifetime
 - **ready_message**: Message sent to validate connection readiness
+- **pool_connection_create_timeout**: Timeout for creating connections in the pool (default: 10 seconds)
+- **pool_get_timeout**: Timeout for acquiring connections from the pool (default: 60 seconds)
 
 ### Methods
 

--- a/docs/clients/service-bus.md
+++ b/docs/clients/service-bus.md
@@ -23,7 +23,9 @@ ManagedAzureServiceBusSender(
     client_limit: int = 100,
     max_size: int = 10,
     max_idle_seconds: int = 300,
-    max_lifespan_seconds: int = None
+    max_lifespan_seconds: int = None,
+    pool_connection_create_timeout: int = 10,
+    pool_get_timeout: int = 60
 )
 ```
 
@@ -36,6 +38,8 @@ ManagedAzureServiceBusSender(
 - **max_size**: Connection pool size
 - **max_idle_seconds**: Connection idle timeout
 - **max_lifespan_seconds**: Maximum connection lifetime
+- **pool_connection_create_timeout**: Timeout for creating connections in the pool (default: 10 seconds)
+- **pool_get_timeout**: Timeout for acquiring connections from the pool (default: 60 seconds)
 
 ### Methods
 

--- a/docs/connection-pooling.md
+++ b/docs/connection-pooling.md
@@ -299,6 +299,8 @@ Default Configuration = 10 × 100 = 1,000 concurrent operations
 | `max_size` | 10 | Number of connections in pool | 2-5 (small), 5-15 (medium), 15-50 (large apps) |
 | `max_idle_seconds` | 300 | Idle timeout before recycling | 60-300 (frequent), 600-1800 (infrequent) |
 | `max_lifespan_seconds` | None | Maximum connection lifetime | 1800-7200 (recommended) |
+| `pool_connection_create_timeout` | 10 | Timeout for creating pool connections | 5-30 seconds based on network latency |
+| `pool_get_timeout` | 60 | Timeout for acquiring pool connections | 30-120 seconds based on load patterns |
 
 ### Configuration Examples
 
@@ -317,7 +319,9 @@ client = ManagedCosmos(
     client_limit=200,        # More concurrent clients
     max_size=20,             # Larger pool
     max_idle_seconds=600,    # Longer retention
-    max_lifespan_seconds=7200  # 2-hour rotation
+    max_lifespan_seconds=7200,  # 2-hour rotation
+    pool_connection_create_timeout=30,  # Allow more time for creation
+    pool_get_timeout=120     # Extended acquisition timeout
 )
 
 # Low-latency configuration
@@ -326,7 +330,9 @@ client = ManagedCosmos(
     client_limit=50,         # Reduced contention
     max_size=5,              # Smaller pool
     max_idle_seconds=60,     # Quick recycling
-    max_lifespan_seconds=1800  # 30-minute rotation
+    max_lifespan_seconds=1800,  # 30-minute rotation
+    pool_connection_create_timeout=5,   # Fast creation timeout
+    pool_get_timeout=30      # Quick acquisition timeout
 )
 
 # Memory-optimized configuration
@@ -335,7 +341,9 @@ client = ManagedCosmos(
     client_limit=25,         # Conservative limit
     max_size=3,              # Minimal pool
     max_idle_seconds=30,     # Aggressive recycling
-    max_lifespan_seconds=600   # 10-minute rotation
+    max_lifespan_seconds=600,   # 10-minute rotation
+    pool_connection_create_timeout=10,  # Default creation timeout
+    pool_get_timeout=60      # Default acquisition timeout
 )
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aio-azure-clients-toolbox"
-version = "0.5.2"
+version = "0.5.3"
 description = "Async Azure Clients Mulligan Python projects"
 authors = [
     { "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aio-azure-clients-toolbox"
-version = "0.5.3"
+version = "0.6.0"
 description = "Async Azure Clients Mulligan Python projects"
 authors = [
     { "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" },

--- a/tests/clients/test_cosmos.py
+++ b/tests/clients/test_cosmos.py
@@ -3,6 +3,10 @@ from unittest import mock
 import pytest
 from aio_azure_clients_toolbox.clients import cosmos
 
+# # # # # # # # # # # # # # # # # #
+# ---**--> Basic Cosmos Client <--**---
+# # # # # # # # # # # # # # # # # #
+
 
 @pytest.fixture()
 def cos_client():
@@ -10,18 +14,14 @@ def cos_client():
         "https://documents.example.com",
         "testing-db",
         "testing-container",
-        mock.Mock(),
+        mock.AsyncMock(),
     )
 
 
-async def test_query(cos_client, cosmos_readable):
-    qclient, set_return = cosmos_readable
-    expected = {"a": "b"}
-    set_return(expected)
-
-    async with cos_client.get_container_client() as client:
-        result = await client.read_item(item="a", partition_key="a")
-        assert result == expected
+def test_get_client(cos_client):
+    # Initial state check
+    assert cos_client.connection_manager.is_container_closed
+    assert cos_client.connection_manager.should_recycle_container
 
 
 async def test_close(cos_client):
@@ -35,3 +35,237 @@ async def test_close(cos_client):
     # Also shouldn't fail (if mocks are set up wrong this will fail)
     await cos_client.close()
     await cos_client.connection_manager.recycle_container()
+
+
+async def test_cosmos_read_item(cos_client, cosmos_readable):
+    qclient, set_return = cosmos_readable
+    expected = {"a": "b"}
+    set_return(expected)
+
+    async with cos_client.get_container_client() as client:
+        result = await client.read_item(item="a", partition_key="a")
+        assert result == expected
+
+
+async def test_cosmos_query_items(cos_client, cosmos_queryable):
+    qclient, set_return = cosmos_queryable
+    expected = [{"id": "1", "name": "test1"}, {"id": "2", "name": "test2"}]
+    set_return(None, side_effect=expected)
+
+    items = []
+    async with cos_client.get_container_client() as client:
+        async for item in client.query_items("SELECT * FROM c"):
+            items.append(item)
+
+    assert items == expected
+
+
+async def test_cosmos_create_item(cos_client, cosmos_insertable):
+    qclient, set_return = cosmos_insertable
+    test_item = {"id": "test", "name": "test item"}
+    set_return(test_item)
+
+    async with cos_client.get_container_client() as client:
+        result = await client.create_item(test_item)
+        assert result == test_item
+
+
+async def test_cosmos_replace_item(cos_client, cosmos_updatable):
+    qclient, set_return = cosmos_updatable
+    test_item = {"id": "test", "name": "updated item"}
+    set_return(test_item)
+
+    async with cos_client.get_container_client() as client:
+        result = await client.replace_item(item="test", body=test_item)
+        assert result == test_item
+
+
+async def test_cosmos_delete_item(cos_client, cosmos_deletable):
+    qclient, set_return = cosmos_deletable
+    set_return(None)
+
+    async with cos_client.get_container_client() as client:
+        await client.delete_item(item="test", partition_key="test")
+        # Just ensure no exception is raised
+
+
+async def test_cosmos_patch_item(cos_client, cosmos_patchable):
+    qclient, set_return = cosmos_patchable
+    patched_item = {"id": "test", "name": "patched item"}
+    set_return(patched_item)
+
+    patch_ops = [{"op": "replace", "path": "/name", "value": "patched item"}]
+    async with cos_client.get_container_client() as client:
+        result = await client.patch_item(
+            item="test", partition_key="test", patch_operations=patch_ops
+        )
+        assert result == patched_item
+
+
+async def test_cosmos_upsert_item(cos_client, cosmos_upsertable):
+    qclient, set_return = cosmos_upsertable
+    test_item = {"id": "test", "name": "upserted item"}
+    set_return(test_item)
+
+    async with cos_client.get_container_client() as client:
+        result = await client.upsert_item(test_item)
+        assert result == test_item
+
+
+# # # # # # # # # # # # # # # # # #
+# ---**--> Simple Cosmos Client <--**---
+# # # # # # # # # # # # # # # # # #
+
+
+@pytest.fixture()
+def simple_cos_client():
+    return cosmos.SimpleCosmos(
+        "https://documents.example.com",
+        "testing-db",
+        "testing-container",
+        mock.AsyncMock(),
+    )
+
+
+async def test_simple_cosmos_get_container_client(simple_cos_client):
+    client = await simple_cos_client.get_container_client()
+    assert client is simple_cos_client
+    assert simple_cos_client._client is not None
+    assert simple_cos_client._db is not None
+    assert simple_cos_client._container is not None
+
+
+async def test_simple_cosmos_close(simple_cos_client):
+    # First create the client
+    await simple_cos_client.get_container_client()
+    assert simple_cos_client._client is not None
+
+    # Now close it
+    await simple_cos_client.close()
+    assert simple_cos_client._client is None
+    assert simple_cos_client._db is None
+    assert simple_cos_client._container is None
+
+
+async def test_simple_cosmos_getattr_without_container(simple_cos_client):
+    # Should raise AttributeError when no container is created
+    with pytest.raises(AttributeError, match="Container client not constructed"):
+        _ = simple_cos_client.read_item
+
+
+async def test_simple_cosmos_getattr_with_container(simple_cos_client, cosmos_readable):
+    qclient, set_return = cosmos_readable
+    expected = {"a": "b"}
+    set_return(expected)
+
+    # Create the container client first
+    await simple_cos_client.get_container_client()
+
+    # Now we should be able to access methods
+    result = await simple_cos_client.read_item(item="a", partition_key="a")
+    assert result == expected
+
+
+# # # # # # # # # # # # # # # # # #
+# ---**--> Managed Cosmos Client <--**---
+# # # # # # # # # # # # # # # # # #
+
+
+@pytest.fixture()
+def managed_cos_client():
+    return cosmos.ManagedCosmos(
+        "https://documents.example.com",
+        "testing-db",
+        "testing-container",
+        mock.AsyncMock(),
+    )
+
+
+async def test_managed_cosmos_create(managed_cos_client):
+    client = await managed_cos_client.create()
+    assert isinstance(client, cosmos.SimpleCosmos)
+    assert client._client is not None
+
+
+async def test_managed_cosmos_close(managed_cos_client):
+    # Set up some connections in the pool
+    async with managed_cos_client.pool.get() as _conn1:
+        async with managed_cos_client.pool.get() as _conn2:
+            pass
+        assert managed_cos_client.pool.ready_connection_count == 2
+
+    await managed_cos_client.close()
+    assert managed_cos_client.pool.ready_connection_count == 0
+
+
+def get_mock_connection_from_pool(pool):
+    # Helper to get the mock connection from the pool
+    return pool._pool[0]._connection
+
+
+async def test_managed_cosmos_get_container_client(managed_cos_client, cosmos_readable):
+    qclient, set_return = cosmos_readable
+    expected = {"id": "1", "data": "test"}
+    set_return(expected)
+
+    async with managed_cos_client.get_container_client() as client:
+        result = await client.read_item(item="1", partition_key="1")
+        assert result == expected
+
+
+async def test_managed_cosmos_runtime_error_handling(
+    managed_cos_client, cosmos_readable
+):
+    qclient, set_return = cosmos_readable
+    set_return(None, side_effect=RuntimeError("Connection failed"))
+
+    with pytest.raises(RuntimeError, match="Connection failed"):
+        async with managed_cos_client.get_container_client() as client:
+            await client.read_item(item="1", partition_key="1")
+
+
+# # # # # # # # # # # # # # # # # #
+# ---**--> Utility Classes <--**---
+# # # # # # # # # # # # # # # # # #
+
+
+def test_patch_op_enum():
+    # Test all PatchOp values
+    assert cosmos.PatchOp.Add.value == "add"
+    assert cosmos.PatchOp.Remove.value == "remove"
+    assert cosmos.PatchOp.Replace.value == "replace"
+    assert cosmos.PatchOp.Set.value == "set"
+    assert cosmos.PatchOp.Incr.value == "incr"
+    assert cosmos.PatchOp.Move.value == "move"
+
+
+def test_patch_op_as_op():
+    # Test regular operations
+    add_op = cosmos.PatchOp.Add.as_op("/path", "value")
+    assert add_op == {"op": "add", "path": "/path", "value": "value"}
+
+    replace_op = cosmos.PatchOp.Replace.as_op("/name", "new_name")
+    assert replace_op == {"op": "replace", "path": "/name", "value": "new_name"}
+
+    # Test move operation (special case)
+    move_op = cosmos.PatchOp.Move.as_op("/from_path", "/to_path")
+    assert move_op == {"op": "move", "from": "/from_path", "path": "/to_path"}
+
+
+def test_operation_dataclass():
+    # Test Operation dataclass
+    op = cosmos.Operation(cosmos.PatchOp.Add, "/test", "test_value")
+    assert op.op == cosmos.PatchOp.Add
+    assert op.path == "/test"
+    assert op.value == "test_value"
+
+    # Test as_op method
+    op_dict = op.as_op()
+    assert op_dict == {"op": "add", "path": "/test", "value": "test_value"}
+
+
+def test_operation_move_dataclass():
+    # Test Operation dataclass with Move operation
+    op = cosmos.Operation(cosmos.PatchOp.Move, "/from", "/to")
+    op_dict = op.as_op()
+    assert op_dict == {"op": "move", "from": "/from", "path": "/to"}

--- a/tests/clients/test_eventhub.py
+++ b/tests/clients/test_eventhub.py
@@ -75,7 +75,9 @@ async def test_evhub_send_events_data_batch(ehub):
 
 
 async def test_managed_get_create(managed_ehub, mockehub):
-    assert await managed_ehub.create() == mockehub
+    close_producer = await managed_ehub.create()
+    assert close_producer is not None
+    assert close_producer._client is mockehub
 
 
 async def test_managed_close(managed_ehub):

--- a/tests/clients/test_service_bus.py
+++ b/tests/clients/test_service_bus.py
@@ -23,7 +23,8 @@ async def test_get_sender(sbus, mockservicebus):
     sender = sbus.get_sender()
     await sender.bla()
     assert mockservicebus._sender.method_calls
-    assert sbus.get_sender() is sender
+    sender2 = sbus.get_sender()
+    assert sender2.attribute is sender.attribute
 
 
 async def test_close(sbus):
@@ -56,7 +57,8 @@ async def test_managed_get_sender(managed_sbus, mockservicebus):
     sender = managed_sbus.get_sender()
     await sender.bla()
     assert mockservicebus._sender.method_calls
-    assert managed_sbus.get_sender() is sender
+    sender2 = managed_sbus.get_sender()
+    assert sender2.attribute is sender.attribute
 
 
 async def test_managed_close(managed_sbus):

--- a/tests/test_connection_pooling.py
+++ b/tests/test_connection_pooling.py
@@ -247,5 +247,7 @@ async def test_connection_pool_close(pool):
 async def test_pool_acquire_timeouts(slow_pool):
     """Check that acquire with timeout moves on sucessfully"""
     with pytest.raises(cp.ConnectionsExhausted):
-        async with slow_pool.get(timeout=SLOW_CONN_SLEEPINESS) as conn:
+        async with slow_pool.get(
+            timeout=SLOW_CONN_SLEEPINESS, acquire_timeout=SLOW_CONN_SLEEPINESS
+        ) as conn:
             assert conn is None

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "aio-azure-clients-toolbox"
-version = "0.5.3"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "aio-azure-clients-toolbox"
-version = "0.5.1"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
### Unclosed Client Credentials ResourceWarnings

Clients may see this message as a `ResourceWarning` on the `__del__` call from the `aiohttp.ClientSession` object. Here's a traceback from elevating this warning to an error:

```
ResourceWarning: Unclosed client session <aiohttp.client.ClientSession object at 0x7eff086ae350>
    _warnings.warn(
  File "/app/.venv/lib/python3.13/site-packages/aiohttp/client.py", line 453, in __del__
Traceback (most recent call last):
Exception ignored in: <function ClientSession.__del__ at 0x7eff37ce13a0>
```

These log messages often appear well after whatever transaction in question has happened. For example, in one notable app, they seem to be connected to `Eventhub` publishing, but they appear seconds or minutes after the connection has been created and used (after the code was invoked and seemingly separated from it). We believe making sure that the credential closes whenever an Eventhub connection is expired can help with this issue.

In other words, whenever we expire connections, we should close our credential connections as well.

In this PR, we are adding `self.credential.close` calls to the `close` method for individual clients of:
- EventhubProducer
- ServiceBusClient 

### Timeout Kwargs Now Setable

Additionally, while testing this, I wanted to set the `max_lifespan_seconds` param to a lower amount in order to surface the bug before checking that this patch fixes it, but I discovered that this param is not passed through to the `ConnectionPool` on the client, so I added pass-through kwargs for the above clients, which will allow callers to tune this param.

More generally, when testing and debugging for this PR, I found it difficult to tune behavior around different timeouts, so I surfaced more kwargs (including above-mentioned `max_lifespan_seconds`) in our connection-pooled clients (EventhubProducer, ServiceBusSender, ManagedCosmos). 

Here, we are now allowing callers to set different timeout values:

```python
      max_lifespan_seconds:
        Optional setting which controls how long a connection lives before recycling.
      pool_connection_create_timeout:
        Timeout for creating a connection in the pool (default: 10 seconds).
      pool_get_timeout:
        Timeout for getting a connection from the pool (default: 60 seconds).
```

### Caveat

These objects may still be garbage-collected outside of the lifecycle events checked as part of connection-pool acquire. In those cases, clients will _still_ see the warning from the `__del__` call for `aiohttp`'s `ClientSession`. To fully resolve the latter, we would likely have to spawn a separate thread with a clock to look at our connection pools and check all the lifespans and disables connections that have lived too long.
