### PR TITLE
Fix v0.6.0 reuse closed-credential bug

### DIFF
--- a/aio_azure_clients_toolbox/clients/eventhub.py
+++ b/aio_azure_clients_toolbox/clients/eventhub.py
@@ -84,10 +84,6 @@ class Eventhub:
         if self._client is not None:
             await self._client.close()
             self._client = None
-        try:
-            await self.credential.close()
-        except Exception as exc:
-            logger.exception(f"Eventhub credential close failed with {exc}")
 
     async def send_event_data(
         self,

--- a/aio_azure_clients_toolbox/clients/eventhub.py
+++ b/aio_azure_clients_toolbox/clients/eventhub.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import traceback
 
@@ -29,7 +30,7 @@ class ProducerClientCloseWrapper:
         self, client: EventHubProducerClient, credential: DefaultAzureCredential
     ):
         self._client = client
-        self._credential = credential
+        self._credential = copy.deepcopy(credential)
 
     def __getattr__(self, name: str):
         return getattr(self._client, name)

--- a/aio_azure_clients_toolbox/clients/eventhub.py
+++ b/aio_azure_clients_toolbox/clients/eventhub.py
@@ -30,7 +30,7 @@ class ProducerClientCloseWrapper:
         self, client: EventHubProducerClient, credential: DefaultAzureCredential
     ):
         self._client = client
-        self._credential = copy.deepcopy(credential)
+        self._credential = copy.copy(credential)
 
     def __getattr__(self, name: str):
         return getattr(self._client, name)

--- a/aio_azure_clients_toolbox/clients/service_bus.py
+++ b/aio_azure_clients_toolbox/clients/service_bus.py
@@ -36,7 +36,7 @@ class SendClientCloseWrapper:
 
     def __init__(self, sender: ServiceBusSender, credential: DefaultAzureCredential):
         self._sender = sender
-        self._credential = copy.deepcopy(credential)
+        self._credential = copy.copy(credential)
 
     def __getattr__(self, name: str):
         return getattr(self._sender, name)

--- a/aio_azure_clients_toolbox/clients/service_bus.py
+++ b/aio_azure_clients_toolbox/clients/service_bus.py
@@ -4,7 +4,7 @@ service_bus.py
 Wrapper class around a `ServiceBusClient` which allows sending messages or
 subscribing to a queue.
 """
-
+import copy
 import datetime
 import logging
 import traceback
@@ -36,7 +36,7 @@ class SendClientCloseWrapper:
 
     def __init__(self, sender: ServiceBusSender, credential: DefaultAzureCredential):
         self._sender = sender
-        self._credential = credential
+        self._credential = copy.deepcopy(credential)
 
     def __getattr__(self, name: str):
         return getattr(self._sender, name)
@@ -95,11 +95,6 @@ class AzureServiceBus:
         return SendClientCloseWrapper(self._sender_client, self.credential)
 
     async def close(self):
-        try:
-            await self.credential.close()
-        except Exception as exc:
-            logger.warning(f"ServiceBus credential close failed with {exc}")
-
         if self._receiver_client is not None:
             await self._receiver_client.close()
             self._receiver_client = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aio-azure-clients-toolbox"
-version = "0.6.0"
+version = "0.6.1"
 description = "Async Azure Clients Mulligan Python projects"
 authors = [
     { "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "aio-azure-clients-toolbox"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Applications using latest v0.6.0 may see repeated attempts to reuse a closed credential. If this happens, the connection-pool loop gets into a catastrophic failure mode, especially in trying to publish ServiceBus messages.

The traceback will likely include a message such as:

```
ValueError("HTTP transport has already been closed. You may check if you're calling a function outside of the `async with` of your client creation, or if you called `await close()` on your client already.")
```

This is especially bad in connection-pool attempts to create a valid ServiceBus sender: each newly created send client fails and so a new client is created up to pool-limit.

Bug appeared in #12 

## Copying Credentials

We have experimented with copying credentials, but `deepcopy` suffers recursive fail after `get_token` call and the `credential` objects stashed on the `DefaultAzureCredential` are _shared_ when performing a shallow copy.

We need a new credential for each client, which means we need a function which generates a new credential object for every client we'd like to create.