### PR TITLE
Breaking change: v1.0.0 -> require credential generator to create managed clients

### DIFF
--- a/aio_azure_clients_toolbox/__init__.py
+++ b/aio_azure_clients_toolbox/__init__.py
@@ -1,3 +1,4 @@
+from .clients import CredentialFactory
 from .clients.azure_blobs import AzureBlobStorageClient
 from .clients.cosmos import Cosmos, ManagedCosmos
 from .clients.eventgrid import EventGridClient, EventGridConfig, EventGridTopicConfig
@@ -5,6 +6,7 @@ from .clients.eventhub import Eventhub, ManagedAzureEventhubProducer
 from .clients.service_bus import AzureServiceBus, ManagedAzureServiceBusSender
 
 __all__ = [
+    "CredentialFactory",
     "AzureBlobStorageClient",
     "Cosmos",
     "ManagedCosmos",

--- a/aio_azure_clients_toolbox/clients/__init__.py
+++ b/aio_azure_clients_toolbox/clients/__init__.py
@@ -3,3 +3,18 @@ from .cosmos import Cosmos, ManagedCosmos
 from .eventgrid import EventGridClient, EventGridConfig, EventGridTopicConfig
 from .eventhub import Eventhub, ManagedAzureEventhubProducer
 from .service_bus import AzureServiceBus, ManagedAzureServiceBusSender
+from .types import CredentialFactory
+
+__all__ = [
+    "AzureBlobStorageClient",
+    "Cosmos",
+    "ManagedCosmos",
+    "EventGridClient",
+    "EventGridConfig",
+    "EventGridTopicConfig",
+    "Eventhub",
+    "ManagedAzureEventhubProducer",
+    "AzureServiceBus",
+    "ManagedAzureServiceBusSender",
+    "CredentialFactory",
+]

--- a/aio_azure_clients_toolbox/clients/cosmos.py
+++ b/aio_azure_clients_toolbox/clients/cosmos.py
@@ -73,16 +73,13 @@ class ConnectionManager:
         dbname: str,
         container_name: str,
         credential_factory: CredentialFactory,
-        credential: DefaultAzureCredential | None = None,
         lifespan_enabled: bool = False,
         cosmos_client_ttl_seconds: int = CLIENT_TTL_SECONDS_DEFAULT,
     ):
         self.endpoint = endpoint
-        if credential is not None:
-            warnings.warn(
-                "Passing a credential instance is deprecated, please pass a credential factory",
-                DeprecationWarning,
-                stacklevel=3,
+        if not callable(credential_factory):
+            raise ValueError(
+                "credential_factory must be a callable returning a credential"
             )
 
         self.db_name = dbname
@@ -182,7 +179,6 @@ class Cosmos:
         dbname: str,
         container_name: str,
         credential_factory: CredentialFactory,
-        credential: DefaultAzureCredential | None = None,
         cosmos_client_ttl_seconds: int = CLIENT_TTL_SECONDS_DEFAULT,
     ):
         self.container_name = container_name
@@ -191,7 +187,6 @@ class Cosmos:
             dbname,
             container_name,
             credential_factory,
-            credential=credential,
             lifespan_enabled=False,
             cosmos_client_ttl_seconds=cosmos_client_ttl_seconds,
         )
@@ -300,7 +295,6 @@ class ManagedCosmos(connection_pooling.AbstractorConnector):
         dbname: str,
         container_name: str,
         credential_factory: CredentialFactory,
-        credential: DefaultAzureCredential | None = None,
         client_limit: int = connection_pooling.DEFAULT_SHARED_TRANSPORT_CLIENT_LIMIT,
         max_size: int = connection_pooling.DEFAULT_MAX_SIZE,
         max_idle_seconds: int = CLIENT_IDLE_SECONDS_DEFAULT,
@@ -311,11 +305,9 @@ class ManagedCosmos(connection_pooling.AbstractorConnector):
         self.endpoint = endpoint
         self.dbname = dbname
         self.container_name = container_name
-        if credential is not None:
-            warnings.warn(
-                "Passing a credential instance is deprecated, please pass a credential factory",
-                DeprecationWarning,
-                stacklevel=3,
+        if not callable(credential_factory):
+            raise ValueError(
+                "credential_factory must be a callable returning a credential"
             )
         self.credential_factory = credential_factory
         self.max_idle_seconds = max_idle_seconds

--- a/aio_azure_clients_toolbox/clients/cosmos.py
+++ b/aio_azure_clients_toolbox/clients/cosmos.py
@@ -2,6 +2,7 @@ import enum
 import logging
 import time
 import traceback
+import warnings
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
@@ -11,6 +12,8 @@ from azure.cosmos.aio import ContainerProxy, CosmosClient
 from azure.identity.aio import DefaultAzureCredential
 
 from aio_azure_clients_toolbox import connection_pooling
+
+from .types import CredentialFactory
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -63,19 +66,28 @@ class Operation:
 
 
 class ConnectionManager:
+
     def __init__(
         self,
         endpoint: str,
         dbname: str,
         container_name: str,
-        credential: DefaultAzureCredential,
+        credential_factory: CredentialFactory,
+        credential: DefaultAzureCredential | None = None,
         lifespan_enabled: bool = False,
         cosmos_client_ttl_seconds: int = CLIENT_TTL_SECONDS_DEFAULT,
     ):
         self.endpoint = endpoint
-        self.credential = credential
+        if credential is not None:
+            warnings.warn(
+                "Passing a credential instance is deprecated, please pass a credential factory",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+
         self.db_name = dbname
         self.container_name = container_name
+        self.credential_factory = credential_factory
         self.client_lifespan_seconds = cosmos_client_ttl_seconds
         self.lifespan_enabled = lifespan_enabled
         if self.lifespan_enabled and not self.client_lifespan_seconds:
@@ -86,6 +98,7 @@ class ConnectionManager:
             raise ValueError(f"Client lifespan must be positive: {self.client_lifespan_seconds}")
 
         # These are clients that must be managed manually
+        self._credential = None
         self._client = None
         self._database = None
         self._container = None
@@ -114,10 +127,6 @@ class ConnectionManager:
     async def recycle_container(self):
         if self._client is not None:
             await self._client.close()
-        try:
-            await self.credential.close()
-        except Exception as exc:
-            logger.warning("Error closing Cosmos credential: %s", exc)
 
         self._client = None
         self._database = None
@@ -136,7 +145,8 @@ class ConnectionManager:
 
         if self.is_container_closed:
             logger.info("Creating new Cosmos client")
-            self._client = CosmosClient(self.endpoint, credential=self.credential)
+            self._credential = self.credential_factory()
+            self._client = CosmosClient(self.endpoint, credential=self._credential)
             self._database = self._client.get_database_client(self.db_name)
             self._container = self._database.get_container_client(self.container_name)
             self._client_lifespan_started = time.monotonic()
@@ -171,7 +181,8 @@ class Cosmos:
         endpoint: str,
         dbname: str,
         container_name: str,
-        credential: DefaultAzureCredential,
+        credential_factory: CredentialFactory,
+        credential: DefaultAzureCredential | None = None,
         cosmos_client_ttl_seconds: int = CLIENT_TTL_SECONDS_DEFAULT,
     ):
         self.container_name = container_name
@@ -179,7 +190,8 @@ class Cosmos:
             endpoint,
             dbname,
             container_name,
-            credential,
+            credential_factory,
+            credential=credential,
             lifespan_enabled=False,
             cosmos_client_ttl_seconds=cosmos_client_ttl_seconds,
         )
@@ -240,6 +252,11 @@ class SimpleCosmos:
         if self._client is not None:
             await self._client.close()
 
+        try:
+            await self.credential.close()
+        except Exception as exc:
+            logger.warning(f"Credential close failed with {exc}")
+
         self._container = None
         self._db = None
         self._client = None
@@ -282,7 +299,8 @@ class ManagedCosmos(connection_pooling.AbstractorConnector):
         endpoint: str,
         dbname: str,
         container_name: str,
-        credential: DefaultAzureCredential,
+        credential_factory: CredentialFactory,
+        credential: DefaultAzureCredential | None = None,
         client_limit: int = connection_pooling.DEFAULT_SHARED_TRANSPORT_CLIENT_LIMIT,
         max_size: int = connection_pooling.DEFAULT_MAX_SIZE,
         max_idle_seconds: int = CLIENT_IDLE_SECONDS_DEFAULT,
@@ -293,7 +311,13 @@ class ManagedCosmos(connection_pooling.AbstractorConnector):
         self.endpoint = endpoint
         self.dbname = dbname
         self.container_name = container_name
-        self.credential = credential
+        if credential is not None:
+            warnings.warn(
+                "Passing a credential instance is deprecated, please pass a credential factory",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+        self.credential_factory = credential_factory
         self.max_idle_seconds = max_idle_seconds
         self.pool = connection_pooling.ConnectionPool(
             self,
@@ -313,7 +337,7 @@ class ManagedCosmos(connection_pooling.AbstractorConnector):
             self.endpoint,
             self.dbname,
             self.container_name,
-            self.credential,
+            self.credential_factory(),
         )
         await client.get_container_client()
         return client
@@ -339,10 +363,6 @@ class ManagedCosmos(connection_pooling.AbstractorConnector):
     async def close(self):
         """Closes all connections in our pool"""
         await self.pool.closeall()
-        try:
-            await self.credential.close()
-        except Exception as exc:
-            logger.warning(f"Credential close failed with {exc}")
 
     @asynccontextmanager
     async def get_container_client(self):

--- a/aio_azure_clients_toolbox/clients/eventhub.py
+++ b/aio_azure_clients_toolbox/clients/eventhub.py
@@ -193,7 +193,6 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
         eventhub_namespace: str,
         eventhub_name: str,
         credential_factory: CredentialFactory,
-        credential: DefaultAzureCredential | None = None,
         eventhub_transport_type: str = TRANSPORT_PURE_AMQP,
         client_limit: int = connection_pooling.DEFAULT_SHARED_TRANSPORT_CLIENT_LIMIT,
         max_size: int = connection_pooling.DEFAULT_MAX_SIZE,
@@ -206,13 +205,11 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
         self.eventhub_namespace = eventhub_namespace
         self.eventhub_name = eventhub_name
         self.eventhub_transport_type = eventhub_transport_type
-        self.credential_factory = credential_factory
-        if credential is not None:
-            warnings.warn(
-                "Passing a credential instance is deprecated, please pass a credential factory",
-                DeprecationWarning,
-                stacklevel=3,
+        if not callable(credential_factory):
+            raise ValueError(
+                "credential_factory must be a callable returning a credential"
             )
+        self.credential_factory = credential_factory
         self.pool = connection_pooling.ConnectionPool(
             self,
             client_limit=client_limit,

--- a/aio_azure_clients_toolbox/clients/service_bus.py
+++ b/aio_azure_clients_toolbox/clients/service_bus.py
@@ -61,17 +61,14 @@ class AzureServiceBus:
         service_bus_namespace_url: str,
         service_bus_queue_name: str,
         credential_factory: CredentialFactory,
-        credential: DefaultAzureCredential | None = None,
     ):
         self.namespace_url = service_bus_namespace_url
         self.queue_name = service_bus_queue_name
-        self.credential_factory = credential_factory
-        if credential is not None:
-            warnings.warn(
-                "Passing a credential instance is deprecated, please pass a credential factory",
-                DeprecationWarning,
-                stacklevel=3,
+        if not callable(credential_factory):
+            raise ValueError(
+                "credential_factory must be a callable returning a credential"
             )
+        self.credential_factory = credential_factory
         self._receiver_client: ServiceBusReceiver | None = None
         self._receiver_credential: DefaultAzureCredential | None = None
         self._sender_client: ServiceBusSender | None = None
@@ -154,7 +151,6 @@ class ManagedAzureServiceBusSender(connection_pooling.AbstractorConnector):
         service_bus_namespace_url: str,
         service_bus_queue_name: str,
         credential_factory: CredentialFactory,
-        credential: DefaultAzureCredential | None = None,
         client_limit: int = connection_pooling.DEFAULT_SHARED_TRANSPORT_CLIENT_LIMIT,
         max_size: int = connection_pooling.DEFAULT_MAX_SIZE,
         max_idle_seconds: int = SERVICE_BUS_SEND_TTL_SECONDS,
@@ -165,13 +161,11 @@ class ManagedAzureServiceBusSender(connection_pooling.AbstractorConnector):
     ):
         self.service_bus_namespace_url = service_bus_namespace_url
         self.service_bus_queue_name = service_bus_queue_name
-        self.credential_factory = credential_factory
-        if credential is not None:
-            warnings.warn(
-                "Passing a credential instance is deprecated, please pass a credential factory",
-                DeprecationWarning,
-                stacklevel=3,
+        if not callable(credential_factory):
+            raise ValueError(
+                "credential_factory must be a callable returning a credential"
             )
+        self.credential_factory = credential_factory
 
         self.pool = connection_pooling.ConnectionPool(
             self,

--- a/aio_azure_clients_toolbox/clients/service_bus.py
+++ b/aio_azure_clients_toolbox/clients/service_bus.py
@@ -8,6 +8,7 @@ subscribing to a queue.
 import datetime
 import logging
 import traceback
+import warnings
 
 from azure.core import exceptions
 from azure.identity.aio import DefaultAzureCredential
@@ -22,6 +23,8 @@ from azure.servicebus.exceptions import (
 )
 
 from aio_azure_clients_toolbox import connection_pooling
+
+from .types import CredentialFactory
 
 # Actual time limit: 240s
 SERVICE_BUS_SEND_TTL_SECONDS = 200
@@ -57,32 +60,35 @@ class AzureServiceBus:
         self,
         service_bus_namespace_url: str,
         service_bus_queue_name: str,
-        credential: DefaultAzureCredential,
+        credential_factory: CredentialFactory,
+        credential: DefaultAzureCredential | None = None,
     ):
         self.namespace_url = service_bus_namespace_url
         self.queue_name = service_bus_queue_name
-        self.credential = credential
-        self._client: ServiceBusClient | None = None
+        self.credential_factory = credential_factory
+        if credential is not None:
+            warnings.warn(
+                "Passing a credential instance is deprecated, please pass a credential factory",
+                DeprecationWarning,
+                stacklevel=3,
+            )
         self._receiver_client: ServiceBusReceiver | None = None
+        self._receiver_credential: DefaultAzureCredential | None = None
         self._sender_client: ServiceBusSender | None = None
 
     def _validate_access_settings(self):
-        if not all((self.namespace_url, self.queue_name, self.credential)):
+        if not all((self.namespace_url, self.queue_name)):
             raise ValueError("Invalid configuration for AzureServiceBus")
         return None
-
-    @property
-    def client(self):
-        if self._client is None:
-            self._validate_access_settings()
-            self._client = ServiceBusClient(self.namespace_url, self.credential)
-        return self._client
 
     def get_receiver(self) -> ServiceBusReceiver:
         if self._receiver_client is not None:
             return self._receiver_client
 
-        self._receiver_client = self.client.get_queue_receiver(
+        credential = self.credential_factory()
+        self._receiver_credential = credential
+        sbc = ServiceBusClient(self.namespace_url, credential)
+        self._receiver_client = sbc.get_queue_receiver(
             queue_name=self.queue_name, receive_mode=ServiceBusReceiveMode.PEEK_LOCK
         )
         return self._receiver_client
@@ -91,26 +97,23 @@ class AzureServiceBus:
         if self._sender_client is not None:
             return self._sender_client
 
-        self._sender_client = self.client.get_queue_sender(queue_name=self.queue_name)
-        return SendClientCloseWrapper(self._sender_client, self.credential)
+        credential = self.credential_factory()
+        sbc = ServiceBusClient(self.namespace_url, credential)
+
+        self._sender_client = sbc.get_queue_sender(queue_name=self.queue_name)
+        return SendClientCloseWrapper(self._sender_client, credential)
 
     async def close(self):
-        try:
-            await self.credential.close()
-        except Exception as exc:
-            logger.warning(f"ServiceBus credential close failed with {exc}")
-
         if self._receiver_client is not None:
             await self._receiver_client.close()
             self._receiver_client = None
+        if self._receiver_credential is not None:
+            await self._receiver_credential.close()
+            self._receiver_credential = None
 
         if self._sender_client is not None:
             await self._sender_client.close()
             self._sender_client = None
-
-        if self._client is not None:
-            await self._client.close()
-            self._client = None
 
     async def send_message(self, msg: str, delay: int = 0):
         message = ServiceBusMessage(msg)
@@ -150,7 +153,8 @@ class ManagedAzureServiceBusSender(connection_pooling.AbstractorConnector):
         self,
         service_bus_namespace_url: str,
         service_bus_queue_name: str,
-        credential: DefaultAzureCredential,
+        credential_factory: CredentialFactory,
+        credential: DefaultAzureCredential | None = None,
         client_limit: int = connection_pooling.DEFAULT_SHARED_TRANSPORT_CLIENT_LIMIT,
         max_size: int = connection_pooling.DEFAULT_MAX_SIZE,
         max_idle_seconds: int = SERVICE_BUS_SEND_TTL_SECONDS,
@@ -161,7 +165,14 @@ class ManagedAzureServiceBusSender(connection_pooling.AbstractorConnector):
     ):
         self.service_bus_namespace_url = service_bus_namespace_url
         self.service_bus_queue_name = service_bus_queue_name
-        self.credential = credential
+        self.credential_factory = credential_factory
+        if credential is not None:
+            warnings.warn(
+                "Passing a credential instance is deprecated, please pass a credential factory",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+
         self.pool = connection_pooling.ConnectionPool(
             self,
             client_limit=client_limit,
@@ -179,7 +190,7 @@ class ManagedAzureServiceBusSender(connection_pooling.AbstractorConnector):
         client = AzureServiceBus(
             self.service_bus_namespace_url,
             self.service_bus_queue_name,
-            self.credential,
+            self.credential_factory,
         )
         return client.get_sender()
 
@@ -195,17 +206,13 @@ class ManagedAzureServiceBusSender(connection_pooling.AbstractorConnector):
         client = AzureServiceBus(
             self.service_bus_namespace_url,
             self.service_bus_queue_name,
-            self.credential,
+            self.credential_factory,
         )
         return client.get_receiver()
 
     async def close(self):
         """Closes all connections in our pool"""
         await self.pool.closeall()
-        try:
-            await self.credential.close()
-        except Exception as exc:
-            logger.warning(f"Credential close failed with {exc}")
 
     @connection_pooling.send_time_deco(logger, "ServiceBus.ready")
     async def ready(self, conn: SendClientCloseWrapper) -> bool:

--- a/aio_azure_clients_toolbox/clients/types.py
+++ b/aio_azure_clients_toolbox/clients/types.py
@@ -1,0 +1,8 @@
+from typing import Protocol
+
+from azure.identity.aio import DefaultAzureCredential
+
+
+class CredentialFactory(Protocol):
+    def __call__(self) -> DefaultAzureCredential:
+        ...

--- a/aio_azure_clients_toolbox/testing_utils/fixtures.py
+++ b/aio_azure_clients_toolbox/testing_utils/fixtures.py
@@ -358,7 +358,7 @@ def sbus(mockservicebus):
     return clients.service_bus.AzureServiceBus(
         "https://sbus.example.com",
         "fake-queue-name",
-        mock.AsyncMock(),  # fake credential
+        lambda: mock.AsyncMock(),  # fake credential
     )
 
 
@@ -367,5 +367,5 @@ def managed_sbus(mockservicebus):
     return clients.service_bus.ManagedAzureServiceBusSender(
         "https://sbus.example.com",
         "fake-queue-name",
-        mock.AsyncMock(),  # fake credential
+        lambda: mock.AsyncMock(),  # fake credential
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aio-azure-clients-toolbox"
-version = "0.6.1"
+version = "1.0.0"
 description = "Async Azure Clients Mulligan Python projects"
 authors = [
     { "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aio-azure-clients-toolbox"
-version = "0.6.0"
+version = "0.6.1"
 description = "Async Azure Clients Mulligan Python projects"
 authors = [
     { "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" },

--- a/tests/clients/test_cosmos.py
+++ b/tests/clients/test_cosmos.py
@@ -14,7 +14,7 @@ def cos_client():
         "https://documents.example.com",
         "testing-db",
         "testing-container",
-        mock.AsyncMock(),
+        lambda: mock.AsyncMock(),
     )
 
 
@@ -177,7 +177,7 @@ def managed_cos_client():
         "https://documents.example.com",
         "testing-db",
         "testing-container",
-        mock.AsyncMock(),
+        lambda: mock.AsyncMock(),
     )
 
 

--- a/tests/clients/test_eventhub.py
+++ b/tests/clients/test_eventhub.py
@@ -24,7 +24,7 @@ def managed_ehub(mockehub):
     return eventhub.ManagedAzureEventhubProducer(
         "namespace_url.example.net",
         "name",
-        mock.AsyncMock(),  # credential
+        lambda: mock.AsyncMock(),  # credential
     )
 
 

--- a/tests/clients/test_service_bus.py
+++ b/tests/clients/test_service_bus.py
@@ -35,7 +35,7 @@ async def test_close(sbus):
     await sbus.close()
     assert sbus._receiver_client is None
     assert sbus._sender_client is None
-    assert sbus._client is None
+    assert sbus._receiver_credential is None
 
 
 async def test_send_message(sbus, mockservicebus):

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "aio-azure-clients-toolbox"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "aio-azure-clients-toolbox"
-version = "0.6.1"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
**Breaking Change**: Connection-pooling clients now require a `credential_factory` to set up: callers must pass a callable which returns a credential.

We found that sharing credentials leads to a lot of headaches.  Applications using latest v0.6.0 may see repeated attempts to reuse a closed credential. If this happens, the connection-pool loop gets into a catastrophic failure mode, especially in trying to publish ServiceBus messages.

The traceback will likely include a message such as:

```
ValueError("HTTP transport has already been closed. You may check if you're calling a function outside of the `async with` of your client creation, or if you called `await close()` on your client already.")
```

This is especially bad in connection-pool attempts to create a valid ServiceBus sender: each newly created send client fails and so a new client is created up to pool-limit.

Bug appeared in #12 

## Solution

Going forward, we plan to require clients to submit a function which returns a `DefaultAzureCredential`, in other words, a function of type: `() -> DefaultAzureCredential`.

We will use this to create a separate credential object for each connection.

Further, we can then experiment with using the context manager to create connections in the future. 