### PR TITLE
Fix: object lifetimes allow close while 1 in use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,5 +111,4 @@ venv.bak/
 
 #misc
 .DS_Store
-
-settings.json
+tmp/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.defaultFormatter": "charliermarsh.ruff",
+  "editor.formatOnSaveMode": "modifications",
+  "editor.formatOnSave": true
+}

--- a/aio_azure_clients_toolbox/clients/eventhub.py
+++ b/aio_azure_clients_toolbox/clients/eventhub.py
@@ -216,7 +216,10 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
             max_idle_seconds=max_idle_seconds,
             max_lifespan_seconds=max_lifespan_seconds,
         )
+        if not isinstance(ready_message, (str, bytes)):
+            raise ValueError("ready_message must be a string or bytes")
         self.ready_message = ready_message
+
         self.pool_kwargs = {
             "timeout": pool_get_timeout,
             "acquire_timeout": pool_connection_create_timeout,

--- a/aio_azure_clients_toolbox/clients/service_bus.py
+++ b/aio_azure_clients_toolbox/clients/service_bus.py
@@ -144,7 +144,7 @@ class ManagedAzureServiceBusSender(connection_pooling.AbstractorConnector):
       pool_get_timeout:
         Timeout for getting a connection from the pool (default: 60 seconds).
       ready_message:
-        A string representing the first "ready" message sent to establish connection.
+        A string or bytes representing the first "ready" message sent to establish connection.
     """
 
     def __init__(
@@ -156,7 +156,7 @@ class ManagedAzureServiceBusSender(connection_pooling.AbstractorConnector):
         max_size: int = connection_pooling.DEFAULT_MAX_SIZE,
         max_idle_seconds: int = SERVICE_BUS_SEND_TTL_SECONDS,
         max_lifespan_seconds: int | None = None,
-        ready_message: str = "Connection established",
+        ready_message: str | bytes = "Connection established",
         pool_connection_create_timeout: int = 10,
         pool_get_timeout: int = 60,
     ):
@@ -166,6 +166,7 @@ class ManagedAzureServiceBusSender(connection_pooling.AbstractorConnector):
             raise ValueError(
                 "credential_factory must be a callable returning a credential"
             )
+
         self.credential_factory = credential_factory
 
         self.pool = connection_pooling.ConnectionPool(
@@ -175,7 +176,10 @@ class ManagedAzureServiceBusSender(connection_pooling.AbstractorConnector):
             max_idle_seconds=max_idle_seconds,
             max_lifespan_seconds=max_lifespan_seconds,
         )
+        if not isinstance(ready_message, (str, bytes)):
+            raise ValueError("ready_message must be a string or bytes")
         self.ready_message = ready_message
+
         self.pool_kwargs = {
             "timeout": pool_get_timeout,
             "acquire_timeout": pool_connection_create_timeout,

--- a/aio_azure_clients_toolbox/connection_pooling.py
+++ b/aio_azure_clients_toolbox/connection_pooling.py
@@ -337,7 +337,7 @@ class SharedTransportConnection:
 
             # Check if TTL exceeded for this connection
             if self.max_lifespan_ns is not None and self.expired:
-                self._should_close = True
+                await self.close()
 
     @asynccontextmanager
     async def acquire(
@@ -360,9 +360,6 @@ class SharedTransportConnection:
         else:
             await self.checkin()
             yield None
-
-        if self._should_close:
-            await self.close()
 
     async def create(self) -> AbstractConnection:
         """Establishes the connection or reuses existing if already created."""

--- a/aio_azure_clients_toolbox/connection_pooling.py
+++ b/aio_azure_clients_toolbox/connection_pooling.py
@@ -205,7 +205,10 @@ class SharedTransportConnection:
     @property
     def available(self):
         """Check if connection exists and client usage limit has been reached"""
-        return self.current_client_count < self.max_clients_allowed
+        return (
+            self.current_client_count < self.max_clients_allowed
+            and not self._should_close
+        )
 
     @property
     def current_client_count(self):
@@ -366,7 +369,6 @@ class SharedTransportConnection:
             if self.max_lifespan_ns is not None:
                 self.connection_created_ts = time.monotonic_ns()
 
-            self._should_close = False
             return self._connection
 
     @property
@@ -408,6 +410,8 @@ class SharedTransportConnection:
             except Exception:
                 pass
 
+            # Reset attributes to initial state
+            self._should_close = False
             self._connection = None
             self._ready = anyio.Event()
             self.last_idle_start = None

--- a/aio_azure_clients_toolbox/connection_pooling.py
+++ b/aio_azure_clients_toolbox/connection_pooling.py
@@ -365,6 +365,8 @@ class SharedTransportConnection:
             # Check if we need to expire connections based on lifespan
             if self.max_lifespan_ns is not None:
                 self.connection_created_ts = time.monotonic_ns()
+
+            self._should_close = False
             return self._connection
 
     @property

--- a/aio_azure_clients_toolbox/connection_pooling.py
+++ b/aio_azure_clients_toolbox/connection_pooling.py
@@ -267,7 +267,7 @@ class SharedTransportConnection:
     def __eq__(self, other):
         return (
             self.is_ready == other.is_ready
-            and self.expired == other.expired
+            and self.should_close == other.should_close
             and self.current_client_count == other.current_client_count
             and self.time_spent_idle == other.time_spent_idle
         )

--- a/aio_azure_clients_toolbox/connection_pooling.py
+++ b/aio_azure_clients_toolbox/connection_pooling.py
@@ -286,8 +286,8 @@ class SharedTransportConnection:
         # Bookkeeping: we want to know how long it takes to acquire a connection
         now = time.monotonic_ns()
 
-        # We use a semaphore to manage client limits
-        await self.client_limiter.acquire()
+        # # We use a semaphore to manage client limits
+        # await self.client_limiter.acquire()
 
         if self.expired and self.current_client_count == 1:
             logger.debug(f"{self} Retiring Connection past its lifespan")
@@ -320,21 +320,23 @@ class SharedTransportConnection:
     async def checkin(self):
         """Called after a connection has been used"""
         # Release the client limit semaphore!
-        try:
-            self.client_limiter.release()
-        except RuntimeError:
-            pass
+        # try:
+        #     self.client_limiter.release()
+        # except RuntimeError:
+        #     pass
 
         logger.debug(f"{self}.current_client_count is now {self.current_client_count}")
 
-        # we only consider idle time to start when *no* clients are connected
-        if self.current_client_count == 0:
+        # we only consider idle time to start when *the last* client checks in
+        if self.current_client_count == 1:
             logger.debug(f"{self} is now idle")
             self.last_idle_start = time.monotonic_ns()
 
-            # Check if TTL exceeded for this connection
-            if self.max_lifespan_ns is not None and self.expired:
-                await self.close()
+            # # Check if TTL exceeded for this connection
+            # if self.max_lifespan_ns is not None and self.expired:
+            #     # Mark for closure, but don't close yet
+            #     self._should_close_after_release = True
+            #     # await self.close()
 
     @asynccontextmanager
     async def acquire(
@@ -342,21 +344,38 @@ class SharedTransportConnection:
     ) -> AsyncGenerator[AbstractConnection | None, None]:
         """Acquire a connection with a timeout"""
         acquired_conn = None
-        async with create_task_group():
-            with move_on_after(timeout) as scope:
-                acquired_conn = await self.checkout()
+        should_close_after = False
+        # Acquire semaphore and release on exit
+        # This also counts the number of clients using this connection.
+        async with self.client_limiter:
+            acquired_conn = None
+            async with create_task_group():
+                with move_on_after(timeout) as scope:
+                    acquired_conn = await self.checkout()
 
-        # If this were nested under `create_task_group` then any exceptions
-        # get thrown under `BaseExceptionGroup`, which is surprising for clients.
-        # See: https://github.com/agronholm/anyio/issues/141
-        if not scope.cancelled_caught and acquired_conn:
-            try:
-                yield acquired_conn
-            finally:
-                await self.checkin()
-        else:
+            # If this were nested under `create_task_group` then any exceptions
+            # get thrown under `BaseExceptionGroup`, which is surprising for clients.
+            # See: https://github.com/agronholm/anyio/issues/141
+            if not scope.cancelled_caught and acquired_conn:
+                try:
+                    yield acquired_conn
+                finally:
+                    # Check if we should close BEFORE releasing semaphore
+                    if (
+                        self.current_client_count == 1
+                        and self.max_lifespan_ns is not None
+                        and self.expired
+                    ):
+                        should_close_after = True
+            else:
+                yield None
+
+            # Set last-idle time after releasing semaphore
             await self.checkin()
-            yield None
+
+            # Semaphore is released here, NOW we can safely close
+            if should_close_after:
+                await self.close()
 
     async def create(self) -> AbstractConnection:
         """Establishes the connection or reuses existing if already created."""
@@ -489,8 +508,8 @@ class ConnectionPool:
                 if _conn.available:
                     async with _conn.acquire(timeout=acquire_timeout) as conn:
                         if conn is not None:
-                            yield conn
                             connection_reached = True
+                            yield conn
                             break
             # Arbitrary async yield to avoid busy loop
             await anyio.sleep(0.01)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,8 @@
 name = "aio-azure-clients-toolbox"
 version = "1.0.0"
 description = "Async Azure Clients Mulligan Python projects"
-authors = [
-    { "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" },
-]
-license = {file = "LICENSE"}
+authors = [{ "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" }]
+license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
@@ -57,12 +55,8 @@ pythonpath = "."
 asyncio_mode = "auto"
 xfail_strict = true
 addopts = "--cov-report term:skip-covered --cov=aio_azure_clients_toolbox --strict-config --strict-markers --cov-report html"
-testpaths = [
-    "tests",
-]
-filterwarnings = [
-    "error"
-]
+testpaths = ["tests"]
+filterwarnings = ["error"]
 
 [tool.ruff]
 src = ["aio_azure_clients_toolbox", "tests"]
@@ -76,13 +70,13 @@ select = [
     "B",  # flake8-bugbear
     "E",  # pycodestyle error
     "F",  # pyflakes
-    "FA",  # flake8-future-annotations
+    "FA", # flake8-future-annotations
     "I",  # isort
     "N",  # pep8-naming
-    "UP",  # pyupgrade
+    "UP", # pyupgrade
     "W",  # pycodestyle warning
 ]
-ignore = ["N818", "N805"]  # exception naming
+ignore = ["N818", "N805"] # exception naming
 
 [tool.ruff.lint.isort]
 force-single-line = false

--- a/tests/test_connection_pooling.py
+++ b/tests/test_connection_pooling.py
@@ -321,3 +321,295 @@ async def test_send_time_deco_with_custom_logger(caplog):
     assert any(
         "Custom logger test timing:" in msg and "ns" in msg for msg in debug_messages
     )
+
+
+# # # # # # # # # # # # # # # # # #
+# ---**--> RACE CONDITION TESTS <--**---
+# # # # # # # # # # # # # # # # # #
+
+
+class ClosableTestConnection(cp.AbstractConnection):
+    """Test connection that tracks if it was closed while still being used"""
+
+    def __init__(self):
+        self.is_closed = False
+        self.usage_count = 0
+        self.used_after_close = False
+
+    async def close(self):
+        self.is_closed = True
+
+    def use(self):
+        """Simulate using the connection - should fail if called after close"""
+        if self.is_closed:
+            self.used_after_close = True
+            raise RuntimeError("Connection used after close!")
+        self.usage_count += 1
+        return f"used_{self.usage_count}"
+
+
+class RaceConditionTestConnector(cp.AbstractorConnector):
+    """Connector that creates trackable test connections"""
+
+    def __init__(self):
+        self.created_connections = []
+
+    async def create(self) -> cp.AbstractConnection:
+        conn = ClosableTestConnection()
+        self.created_connections.append(conn)
+        return conn
+
+    async def ready(self, connection: cp.AbstractConnection) -> bool:
+        return True
+
+
+@pytest.fixture
+def race_condition_shared_conn():
+    """Shared connection with very short lifespan to trigger race conditions"""
+    return cp.SharedTransportConnection(
+        RaceConditionTestConnector(),
+        client_limit=3,
+        max_idle_seconds=0.001,  # Very short to trigger expiry quickly
+        max_lifespan_seconds=0.002,  # Even shorter lifespan
+    )
+
+
+@pytest.fixture
+def race_condition_pool():
+    """Connection pool with very short lifespans to trigger race conditions"""
+    return cp.ConnectionPool(
+        RaceConditionTestConnector(),
+        client_limit=3,
+        max_size=1,
+        max_idle_seconds=0.001,
+        max_lifespan_seconds=0.002,
+    )
+
+
+# FAILING TESTS - These expose the race condition bugs
+
+
+# @pytest.mark.xfail(
+#     reason="Race condition: connection closed while other clients still using it"
+# )
+async def test_race_condition_lifespan_expiry_during_usage(race_condition_shared_conn):
+    """FAILING TEST: Exposes race condition where connection gets closed while other clients are using it"""
+    results = []
+    exceptions = []
+
+    async def client_a():
+        """Client that will trigger the expiry"""
+        try:
+            async with race_condition_shared_conn.acquire() as conn:
+                conn.use()  # Use connection
+                await sleep(0.003)  # Hold it past lifespan
+                results.append("Client A done")
+        except Exception as e:
+            exceptions.append(("Client A", e))
+
+    async def client_b():
+        """Client that gets same connection but may find it closed"""
+        try:
+            await sleep(0.001)  # Let client A get connection first
+            async with race_condition_shared_conn.acquire() as conn:
+                await sleep(0.001)  # Let client A potentially close connection
+                result = conn.use()  # This should fail if connection was closed
+                results.append(f"Client B: {result}")
+        except Exception as e:
+            exceptions.append(("Client B", e))
+
+    # Run both clients concurrently
+    await asyncio.gather(client_a(), client_b())
+
+    # If race condition exists, client B should get an exception
+    # because the connection was closed while it was still using it
+    assert len(exceptions) == 0, f"Race condition detected: {exceptions}"
+    assert len(results) == 2, f"Expected 2 successful results, got: {results}"
+
+
+# @pytest.mark.xfail(
+#     reason="Race condition: connection expires during checkout-checkin window"
+# )
+async def test_race_condition_checkout_expiry_window(race_condition_shared_conn):
+    """FAILING TEST: Exposes race condition in checkout when connection expires"""
+
+    # First, let's create and expire a connection
+    async with race_condition_shared_conn.acquire() as conn:
+        conn.use()
+
+    # Wait for expiry
+    await sleep(0.005)
+
+    # Now multiple clients try to get the expired connection simultaneously
+    results = []
+    exceptions = []
+
+    async def concurrent_client(client_id):
+        try:
+            async with race_condition_shared_conn.acquire() as conn:
+                if conn is None:
+                    results.append(f"Client {client_id}: None")
+                else:
+                    result = conn.use()
+                    results.append(f"Client {client_id}: {result}")
+        except Exception as e:
+            exceptions.append((f"Client {client_id}", e))
+
+    # Run multiple clients concurrently to trigger race condition in checkout
+    await asyncio.gather(
+        concurrent_client(1), concurrent_client(2), concurrent_client(3)
+    )
+
+    # Check that no client got a closed connection
+    assert len(exceptions) == 0, f"Race condition in checkout: {exceptions}"
+    closed_usage = any("used after close" in str(e) for _, e in exceptions)
+    assert not closed_usage, "Connection was used after being closed"
+
+
+# @pytest.mark.xfail(reason="Race condition: pool yields closed connections")
+async def test_race_condition_pool_yields_closed_connection(race_condition_pool):
+    """FAILING TEST: Exposes race condition where pool yields closed connections"""
+    exceptions = []
+    results = []
+
+    async def client_with_delay(client_id, delay):
+        try:
+            await sleep(delay)
+            async with race_condition_pool.get() as conn:
+                if conn is None:
+                    results.append(f"Client {client_id}: None")
+                else:
+                    result = conn.use()
+                    results.append(f"Client {client_id}: {result}")
+                    # Hold connection to trigger expiry
+                    await sleep(0.003)
+        except Exception as e:
+            exceptions.append((f"Client {client_id}", e))
+
+    # Start multiple clients with staggered timing
+    await asyncio.gather(
+        client_with_delay(1, 0.0),  # Starts immediately
+        client_with_delay(2, 0.001),  # Starts slightly later
+        client_with_delay(3, 0.002),  # Starts even later
+    )
+
+    # Check for race condition indicators
+    assert len(exceptions) == 0, f"Race condition detected: {exceptions}"
+    used_after_close_errors = [
+        e for _, e in exceptions if "Connection used after close" in str(e)
+    ]
+    assert len(used_after_close_errors) == 0, "Connection was used after being closed"
+
+
+# PASSING TESTS - These verify existing behavior and catch regressions
+
+
+async def test_no_regression_normal_connection_sharing(race_condition_pool):
+    """PASSING TEST: Ensures normal connection sharing still works without race conditions"""
+    results = []
+
+    async def normal_client(client_id):
+        async with race_condition_pool.get() as conn:
+            result = conn.use()
+            results.append(f"Client {client_id}: {result}")
+            await sleep(0.0001)  # Very short usage, well within lifespan
+
+    # Run clients that should share connections successfully
+    await asyncio.gather(
+        normal_client(1),
+        normal_client(2),
+        normal_client(3),
+    )
+
+    assert len(results) == 3
+    assert all("used_" in result for result in results)
+
+
+async def test_no_regression_connection_cleanup_after_idle():
+    """PASSING TEST: Ensures connections are properly cleaned up after idle timeout"""
+    connector = RaceConditionTestConnector()
+    shared_conn = cp.SharedTransportConnection(
+        connector,
+        client_limit=2,
+        max_idle_seconds=0.01,
+    )
+
+    # Use connection and let it go idle
+    async with shared_conn.acquire() as conn:
+        conn.use()
+
+    # Verify it's idle
+    assert shared_conn.current_client_count == 0
+    assert shared_conn.last_idle_start is not None
+
+    # Wait for idle timeout
+    await sleep(0.02)
+
+    # Connection should be marked as expired
+    assert shared_conn.expired
+
+    # Next acquisition should clean up the expired connection
+    async with shared_conn.acquire() as conn:
+        conn.use()
+
+    # Should have created a new connection (old one was cleaned up)
+    assert len(connector.created_connections) >= 1
+
+
+async def test_no_regression_semaphore_limits_enforced(race_condition_shared_conn):
+    """PASSING TEST: Ensures semaphore limits are still properly enforced"""
+    # The fixture has client_limit=3
+    acquired_connections = []
+
+    async def try_acquire(client_id):
+        try:
+            async with race_condition_shared_conn.acquire(timeout=0.01) as conn:
+                if conn is not None:
+                    acquired_connections.append(client_id)
+                    await sleep(
+                        0.02
+                    )  # Hold connection longer than timeout to block others
+        except Exception:
+            pass  # Timeout expected for excess clients
+
+    # Try to acquire more connections than the limit allows
+    await asyncio.gather(
+        try_acquire(1),
+        try_acquire(2),
+        try_acquire(3),
+        try_acquire(4),  # This should timeout
+        try_acquire(5),  # This should timeout
+    )
+
+    # Should not exceed the client limit of 3
+    assert len(acquired_connections) <= 3
+
+
+async def test_no_regression_pool_heap_ordering():
+    """PASSING TEST: Ensures pool still maintains proper heap ordering for connection freshness"""
+    pool = cp.ConnectionPool(
+        RaceConditionTestConnector(),
+        client_limit=2,
+        max_size=3,
+        max_idle_seconds=0.1,
+    )
+
+    # Use connections to establish different idle times
+    async with pool.get() as conn1:
+        conn1.use()
+        await sleep(0.001)
+
+    await sleep(0.002)  # Let first connection become more idle
+
+    async with pool.get() as conn2:
+        conn2.use()
+
+    # Pool should maintain heap ordering (freshest connections first)
+    # This is verified by the internal heap structure
+    import heapq
+
+    assert len(pool._pool) == 3
+    # Heap property should be maintained
+    heap_copy = pool._pool.copy()
+    heapq.heapify(heap_copy)
+    assert heap_copy == pool._pool


### PR DESCRIPTION
We found that it is possible to use a client immediately after closing, because our shared connection class's `CapacityLimiter` is functioning as a reference-counter, but as a reference-counter, because of where it's incremented and decremented, it turns out it's not strict enough to be relevant for the action we're taking, namely **closing expired connections**.

In other words, the `checkout()` and `checkin()` were not _strict_ enough for _relying on_ the `CapacityLimiter` to truly understand: do we have 1 or 0 clients currently using this shared connection?

**What Has Been Changed**

This PR attempts to fix this bug by:

- Make `checkin` no longer `close()` expired connections: instead set a flag that they _should be closed soon_
- Move the `CapacityLimiter` decrement to _wrap_ all the connection-yield _and_ `checkout()` and `checkin()` logic
- In the `ConnectionPool` pass over (do not yield) connections which have the `should_close` flag set
- In the `ConnectionPool`, close connections which have the `should_close` flag set

I also bumped up the number of available connections we iterate through in the heap. I don't really remember why it was half: probably because connections are getting created and heapify called a lot? This was a random, passing thing, but now I can't remember the original goal, so I'll have to think about it. It's likely this change should be separated out.

**What This Bug Looks Like in the Wild**

This bug can surface as tracebacks like the following:

```
  File "/app/somebodys_application/clients/cosmos.py", line 225, in query_docs
    query_results = client.query_items(
                    ^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/aio_azure_clients_toolbox/clients/cosmos.py", line 239, in __getattr__
    raise AttributeError("Container client not constructed")
AttributeError: Container client not constructed
```

The goal is to make this safter **without** requiring a lock around all interesting actions that can be taken for an open connection. We want to continue to allow unrestricted use of the connection, so the goal is to make sure we don't accidentally close a connection while a caller still has one checked out.

**Miscellaneous Change Thrown In**

We also found that `EventData` says it takes type `str | bytes` but you can put arbitrary python objects in there and cause some really weird stuff to happen for receivers. For this reason, we are now throwing a ValueError for any client that attempts to initialize with a ready_message which isn't `str | bytes`.