### PR TITLE
BlobStorage: Add list_blobs 

### DIFF
--- a/tests/clients/test_azure_blobs.py
+++ b/tests/clients/test_azure_blobs.py
@@ -129,7 +129,6 @@ async def test_upload_blob(with_error, absc, mock_azureblob):
         mockblobc.upload_blob.assert_called_once_with("somedata", blob_type="BlockBlob")
     else:
         expected = {"status": "success"}
-        mockblobc.upload_blob.side_effect = None
         mockblobc.upload_blob.return_value = expected
         result1 = await absc.upload_blob("hey", "somedata")
         assert result1[0] is True

--- a/tests/clients/test_azure_blobs.py
+++ b/tests/clients/test_azure_blobs.py
@@ -149,8 +149,6 @@ async def test_upload_blob(with_error, absc, mock_azureblob):
 
 
 async def test_list_blobs(absc, mock_azureblob):
-    # We don't have a specific implementation of this method, but we need to make sure
-    # our pytest fixture for it works.
     container_client, _, set_return = mock_azureblob
     set_return.list_blobs_returns([
         BlobProperties(name="some-blob", last_modified="2023-01-01T00:00:00Z"),
@@ -158,6 +156,6 @@ async def test_list_blobs(absc, mock_azureblob):
         BlobProperties(name="some-blob3", last_modified="2023-01-01T00:00:00Z"),
     ])
 
-    blob_names = [b.name async for b in container_client.list_blobs()]
+    blob_names = [b.name async for b in absc.list_blobs()]
     assert len(blob_names) == 3
     assert blob_names == ["some-blob", "some-blob2", "some-blob3"]


### PR DESCRIPTION
Some of the callers of this library have to implement `list_blobs` by wrapping `get_container_client`. It's straightforward to add it here, however. In addition, we _already had a test for this functionality_ (even though unimplemented previously).

Example:

```python
In [2]: blob_client = clients.blobs.AzureBlobStorageClient(settings.az_storage_url,settings.az_credential(), setting
      ⋮ s.file_workspace_dir)

In [3]: prefix=lambda eid: f"documents/{eid}"

In [4]: async for blob in blob_client.list_blobs(prefix("94n6460d7ac905186z13741")):
   ...:     print(blob.name)
   ...:
documents/0416460d7ac905186e13741/00aloadsofincomev2.json
documents/0416460d7ac905186e13741/2025-10-07 (17:11:13) - Generated Merchant Account 1072025, 5:10 PM - New Business.xlsx
documents/0416460d7ac905186e13741/envelope.meta
```

**Note**: this is the last expected change before the 1.0.0 release.

**Fixtures**

I also overhauled the Blob Storage fixtures provided by this library, which _may_ result in clients having to rework tests expecting attributes or methods on a _blended_ `BlobClient` thing. Instead, I mapped mock objects to the _real_ underlying hierarchy at work here, so it's hopefully less confusing.