### PR TITLE
Fix outdated docstrings still referencing `credential` instead of `credential_factory`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,9 @@
 {
-  "editor.defaultFormatter": "charliermarsh.ruff",
-  "editor.formatOnSaveMode": "modifications",
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "ruff.lineLength": 110,
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSaveMode": "modifications",
+    "editor.formatOnSave": true
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.formatOnSave": true,
-  "ruff.lineLength": 110,
+  "ruff.lineLength": 120,
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff",
     "editor.formatOnSaveMode": "modifications",

--- a/aio_azure_clients_toolbox/clients/cosmos.py
+++ b/aio_azure_clients_toolbox/clients/cosmos.py
@@ -276,8 +276,8 @@ class ManagedCosmos(connection_pooling.AbstractorConnector):
         Cosmos database name.
       container_name:
         Cosmos container name.
-      credential:
-        An async DefaultAzureCredential which may be used to authenticate to the container.
+      credential_factory:
+        A callable that returns an async DefaultAzureCredential which may be used to authenticate to the container.
       client_limit:
         Client limit per connection (default: 100).
       max_size:

--- a/aio_azure_clients_toolbox/clients/eventhub.py
+++ b/aio_azure_clients_toolbox/clients/eventhub.py
@@ -169,8 +169,8 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
         String representing the Eventhub namespace.
       eventhub_name:
         Eventhub name (the "topic").
-      credential:
-        An async DefaultAzureCredential which may be used to authenticate to the container.
+      credential_factory:
+        A callable that returns an async DefaultAzureCredential which may be used to authenticate to the container.
       client_limit:
         Client limit per connection (default: 100).
       max_size:

--- a/aio_azure_clients_toolbox/clients/service_bus.py
+++ b/aio_azure_clients_toolbox/clients/service_bus.py
@@ -129,8 +129,8 @@ class ManagedAzureServiceBusSender(connection_pooling.AbstractorConnector):
         String representing the ServiceBus namespace URL.
       service_bus_queue_name:
         Queue name (the "topic").
-      credential:
-        An async DefaultAzureCredential which may be used to authenticate to the container.
+      credential_factory:
+        A callable that returns an async DefaultAzureCredential which may be used to authenticate to the container.
       client_limit:
         Client limit per connection (default: 100).
       max_size:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aio-azure-clients-toolbox"
-version = "1.0.1"
+version = "1.0.2"
 description = "Async Azure Clients Mulligan Python projects"
 authors = [{ "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" }]
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ src = ["aio_azure_clients_toolbox", "tests"]
 fix = true
 show-fixes = true
 output-format = "full"
-line-length = 110
+line-length = 120
 
 [tool.ruff.lint]
 select = [

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "aio-azure-clients-toolbox"
-version = "1.0.0"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
I keep getting duped by these unchanged docstrings.