### PR TITLE
Allows connstr for eventhub producers

### DIFF
--- a/aio_azure_clients_toolbox/clients/eventhub.py
+++ b/aio_azure_clients_toolbox/clients/eventhub.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 class Eventhub:
     __slots__ = [
+        "connection_string",
         "credential",
         "evhub_name",
         "evhub_namespace",
@@ -35,12 +36,18 @@ class Eventhub:
         self,
         eventhub_namespace: str,
         eventhub_name: str,
-        credential: DefaultAzureCredential,
+        credential: DefaultAzureCredential | None = None,
         eventhub_transport_type: str = TRANSPORT_PURE_AMQP,
+        connection_string: str | None = None,
     ):
+        if not any([isinstance(connection_string, str), credential is not None]):
+            raise ValueError(
+                "credential must be a DefaultAzureCredential or connection_string must be a string"
+            )
         self.evhub_namespace = eventhub_namespace
         self.evhub_name = eventhub_name
         self.credential = credential
+        self.connection_string = connection_string
         self.transport_type = (
             {}
             if eventhub_transport_type == TRANSPORT_PURE_AMQP
@@ -52,6 +59,13 @@ class Eventhub:
         return getattr(self._client, name)
 
     def get_client(self) -> EventHubProducerClient:
+        if self.connection_string is not None:
+            return EventHubProducerClient.from_connection_string(
+                self.connection_string,
+                eventhub_name=self.evhub_name,
+                **cast(Any, self.transport_type),
+            )
+        assert self.credential is not None, "credential must be set when connection_string is not provided"
         return EventHubProducerClient(
             fully_qualified_namespace=self.evhub_namespace,
             eventhub_name=self.evhub_name,
@@ -69,10 +83,11 @@ class Eventhub:
         if self._client is not None:
             await self._client.close()
             self._client = None
-        try:
-            await self.credential.close()
-        except Exception as exc:
-            logger.exception(f"Eventhub credential close failed with {exc}")
+        if self.credential is not None:
+            try:
+                await self.credential.close()
+            except Exception as exc:
+                logger.exception(f"Eventhub credential close failed with {exc}")
 
     async def send_event_data(
         self,
@@ -195,7 +210,7 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
         self,
         eventhub_namespace: str,
         eventhub_name: str,
-        credential_factory: CredentialFactory,
+        credential_factory: CredentialFactory | None = None,
         eventhub_transport_type: str = TRANSPORT_PURE_AMQP,
         client_limit: int = connection_pooling.DEFAULT_SHARED_TRANSPORT_CLIENT_LIMIT,
         max_size: int = connection_pooling.DEFAULT_MAX_SIZE,
@@ -204,14 +219,16 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
         max_lifespan_seconds: int | None = None,
         pool_connection_create_timeout: int = 10,
         pool_get_timeout: int = 60,
+        connection_string: str | None = None,
         max_concurrent_creates: int | None = None,
     ):
         self.eventhub_namespace = eventhub_namespace
         self.eventhub_name = eventhub_name
         self.eventhub_transport_type = eventhub_transport_type
-        if not callable(credential_factory):
+        self.connection_string = connection_string
+        if not any([isinstance(connection_string, str), callable(credential_factory)]):
             raise ValueError(
-                "credential_factory must be a callable returning a credential"
+                "credential_factory must be a callable returning a credential or connection_string must be a string"
             )
         self.credential_factory = credential_factory
         self.pool = connection_pooling.ConnectionPool(
@@ -236,8 +253,9 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
         return cast(connection_pooling.AbstractConnection, Eventhub(
             self.eventhub_namespace,
             self.eventhub_name,
-            self.credential_factory(),
+            self.credential_factory() if self.credential_factory is not None else None,
             eventhub_transport_type=self.eventhub_transport_type,
+            connection_string=self.connection_string,
         ))
 
     async def close(self):

--- a/aio_azure_clients_toolbox/clients/eventhub.py
+++ b/aio_azure_clients_toolbox/clients/eventhub.py
@@ -23,6 +23,27 @@ logger = logging.getLogger(__name__)
 
 
 class Eventhub:
+    """Low-level EventHub producer client without connection pooling.
+
+    For connection pooling see ``ManagedAzureEventhubProducer`` below.
+
+    Args:
+      eventhub_namespace:
+        Fully-qualified EventHub namespace hostname
+        (e.g. ``"myns.servicebus.windows.net"``).
+      eventhub_name:
+        EventHub name (the "topic").
+      credential:
+        An async ``DefaultAzureCredential`` instance.  Mutually exclusive with
+        ``connection_string``; exactly one must be supplied.
+      eventhub_transport_type:
+        Transport protocol.  Pass ``"amqp"`` (default) for pure AMQP or any
+        other value to use AMQP-over-WebSocket.
+      connection_string:
+        An Azure Event Hubs connection string.  Mutually exclusive with
+        ``credential``; exactly one must be supplied.
+    """
+
     __slots__ = [
         "connection_string",
         "credential",
@@ -186,7 +207,8 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
       eventhub_name:
         Eventhub name (the "topic").
       credential_factory:
-        A callable that returns an async DefaultAzureCredential which may be used to authenticate to the container.
+        A callable that returns an async ``DefaultAzureCredential``.  Mutually
+        exclusive with ``connection_string``; exactly one must be supplied.
       client_limit:
         Client limit per connection (default: 100).
       max_size:
@@ -204,6 +226,9 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
         pool slots. Defaults to ``max(max_size // 3, 1)``.
       ready_message:
         A string, bytes, or EventData object representing the first "ready" message sent to establish connection.
+      connection_string:
+        An Azure Event Hubs connection string.  Mutually exclusive with
+        ``credential_factory``; exactly one must be supplied.
     """
 
     def __init__(

--- a/aio_azure_clients_toolbox/clients/service_bus.py
+++ b/aio_azure_clients_toolbox/clients/service_bus.py
@@ -54,6 +54,20 @@ class AzureServiceBus:
     Basic AzureServiceBus client without connection pooling.
 
     For connection pooling see `ManagedAzureServiceBus` below.
+
+    Args:
+      service_bus_namespace_url:
+        String representing the ServiceBus namespace URL.
+      service_bus_queue_name:
+        Queue name.
+      credential_factory:
+        A callable that returns an async ``DefaultAzureCredential``.  Mutually
+        exclusive with ``connection_string``; exactly one must be supplied.
+      socket_timeout:
+        Socket timeout in seconds (default: 1).  Azure's own default is 0.2 s.
+      connection_string:
+        An Azure Service Bus connection string.  Mutually exclusive with
+        ``credential_factory``; exactly one must be supplied.
     """
 
     def __init__(
@@ -164,7 +178,8 @@ class ManagedAzureServiceBusSender(connection_pooling.AbstractorConnector):
       service_bus_queue_name:
         Queue name (the "topic").
       credential_factory:
-        A callable that returns an async DefaultAzureCredential which may be used to authenticate to the container.
+        A callable that returns an async ``DefaultAzureCredential``.  Mutually
+        exclusive with ``connection_string``; exactly one must be supplied.
       client_limit:
         Client limit per connection (default: 100).
       max_size:
@@ -174,7 +189,7 @@ class ManagedAzureServiceBusSender(connection_pooling.AbstractorConnector):
       max_lifespan_seconds:
         Optional setting which controls how long a connection lives before recycling.
       pool_connection_create_timeout:
-       Timeout for creating a connection in the pool (default: 10 seconds).
+        Timeout for creating a connection in the pool (default: 10 seconds).
       pool_get_timeout:
         Timeout for getting a connection from the pool (default: 60 seconds).
       max_concurrent_creates:
@@ -182,6 +197,9 @@ class ManagedAzureServiceBusSender(connection_pooling.AbstractorConnector):
         pool slots. Defaults to ``max(max_size // 3, 1)``.
       ready_message:
         A string or bytes representing the first "ready" message sent to establish connection.
+      connection_string:
+        An Azure Service Bus connection string.  Mutually exclusive with
+        ``credential_factory``; exactly one must be supplied.
     """
 
     def __init__(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aio-azure-clients-toolbox"
-version = "1.4.0"
+version = "1.4.1"
 description = "Async Azure Clients Mulligan Python projects"
 authors = [{ "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" }]
 license = { file = "LICENSE" }

--- a/tests/clients/test_eventhub.py
+++ b/tests/clients/test_eventhub.py
@@ -244,6 +244,78 @@ def test_managed_bad_credential():
         )
 
 
+def test_managed_neither_credential_nor_connection_string():
+    """Neither credential_factory nor connection_string raises ValueError."""
+    with pytest.raises(ValueError, match="credential_factory must be a callable"):
+        eventhub.ManagedAzureEventhubProducer(
+            "namespace_url.example.net",
+            "name",
+        )
+
+
+def test_managed_connection_string(mockehub):
+    """ManagedAzureEventhubProducer can be constructed with a connection_string."""
+    producer = eventhub.ManagedAzureEventhubProducer(
+        "namespace_url.example.net",
+        "name",
+        connection_string="Endpoint=sb://fake.servicebus.windows.net/;SharedAccessKeyName=key;SharedAccessKey=abc",
+    )
+    assert producer.connection_string is not None
+    assert producer.credential_factory is None
+
+
+def test_eventhub_connection_string(monkeypatch):
+    """Eventhub.get_client uses from_connection_string when connection_string is set."""
+    from unittest import mock
+
+    from azure.eventhub.aio import EventHubProducerClient
+
+    fake_client = mock.MagicMock(spec=EventHubProducerClient)
+    from_conn_str = mock.MagicMock(return_value=fake_client)
+    monkeypatch.setattr(EventHubProducerClient, "from_connection_string", from_conn_str)
+    # Also patch get_client so __init__ doesn't try to call from_connection_string twice
+    conn_str = "Endpoint=sb://fake.servicebus.windows.net/;SharedAccessKeyName=key;SharedAccessKey=abc"
+    ehub = eventhub.Eventhub(
+        "namespace_url.example.net",
+        "name",
+        connection_string=conn_str,
+    )
+    assert ehub.connection_string == conn_str
+    assert ehub.credential is None
+
+
+def test_eventhub_neither_credential_nor_connection_string():
+    """Eventhub raises ValueError when neither credential nor connection_string is provided."""
+    with pytest.raises(ValueError, match="credential must be a DefaultAzureCredential"):
+        eventhub.Eventhub(
+            "namespace_url.example.net",
+            "name",
+        )
+
+
+async def test_managed_create_with_connection_string(mockehub):
+    """ManagedAzureEventhubProducer.create() works with connection_string (no credential_factory)."""
+    producer = eventhub.ManagedAzureEventhubProducer(
+        "namespace_url.example.net",
+        "name",
+        connection_string="Endpoint=sb://fake.servicebus.windows.net/;SharedAccessKeyName=key;SharedAccessKey=abc",
+    )
+    conn = await producer.create()
+    assert conn is not None
+    assert conn._client is mockehub
+
+
+async def test_close_with_no_credential(mockehub):
+    """Eventhub.close() does not raise when credential is None (connection_string path)."""
+    ehub = eventhub.Eventhub(
+        "namespace_url.example.net",
+        "name",
+        connection_string="Endpoint=sb://fake.servicebus.windows.net/;SharedAccessKeyName=key;SharedAccessKey=abc",
+    )
+    await ehub.close()  # should not raise
+    assert ehub._client is None
+
+
 async def test_managed_evhub_send_events_data_batch(mockehub_throwing, managed_ehub):
     batch = EventDataBatch()
     batch.add(EventData(body=b"test1"))

--- a/tests/clients/test_eventhub.py
+++ b/tests/clients/test_eventhub.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 from aio_azure_clients_toolbox.clients import eventhub
 from azure.eventhub import EventData, EventDataBatch
+from azure.eventhub.aio import EventHubProducerClient
 from azure.eventhub.exceptions import AuthenticationError, ClientClosedError, ConnectError
 
 # Three calls to send a ready message
@@ -266,10 +267,6 @@ def test_managed_connection_string(mockehub):
 
 def test_eventhub_connection_string(monkeypatch):
     """Eventhub.get_client uses from_connection_string when connection_string is set."""
-    from unittest import mock
-
-    from azure.eventhub.aio import EventHubProducerClient
-
     fake_client = mock.MagicMock(spec=EventHubProducerClient)
     from_conn_str = mock.MagicMock(return_value=fake_client)
     monkeypatch.setattr(EventHubProducerClient, "from_connection_string", from_conn_str)

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "aio-azure-clients-toolbox"
-version = "1.4.0"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
We recently allowed (in pr #25 ) `connection_string` for ServiceBus and we want to allow the same for EventhubProducerClient because it's improves our ability to [run simulations](https://learn.microsoft.com/en-us/azure/event-hubs/test-locally-with-event-hub-emulator?tabs=docker-linux-container%2Cusing-kafka).

This PR adds:
- Eventhub connection_string as option vs credential
- tests for above
- documentation update for above and preivous servicebus change