### PR TITLE
Fix critical error where None passed for transport_type causes a crash

### DIFF
--- a/aio_azure_clients_toolbox/clients/eventhub.py
+++ b/aio_azure_clients_toolbox/clients/eventhub.py
@@ -37,7 +37,10 @@ class Eventhub:
         An async ``DefaultAzureCredential`` instance.  Mutually exclusive with
         ``connection_string``; exactly one must be supplied.
       eventhub_transport_type:
-        Transport protocol of type ``azure.eventhub.TransportType``.
+        Transport protocol.  Must be an ``azure.eventhub.TransportType`` instance
+        or ``None`` (default).  ``None`` omits the argument entirely, letting the
+        SDK choose its default (AMQP).  Any non-``TransportType`` value emits a
+        ``UserWarning`` and is treated as ``None``.
       connection_string:
         An Azure Event Hubs connection string.  Mutually exclusive with
         ``credential``; exactly one must be supplied.
@@ -49,7 +52,7 @@ class Eventhub:
         "evhub_name",
         "evhub_namespace",
         "_client",
-        "transport_type",
+        "client_kwargs",
     ]
 
     def __init__(
@@ -75,7 +78,9 @@ class Eventhub:
                 stacklevel=2,
             )
             eventhub_transport_type = None
-        self.transport_type = eventhub_transport_type
+        self.client_kwargs: dict[str, Any] = (
+            {"transport_type": eventhub_transport_type} if eventhub_transport_type is not None else {}
+        )
         self._client: EventHubProducerClient | None = self.get_client()
 
     def __getattr__(self, name):
@@ -86,14 +91,14 @@ class Eventhub:
             return EventHubProducerClient.from_connection_string(
                 self.connection_string,
                 eventhub_name=self.evhub_name,
-                **cast(Any, self.transport_type),
+                **self.client_kwargs,
             )
         assert self.credential is not None, "credential must be set when connection_string is not provided"
         return EventHubProducerClient(
             fully_qualified_namespace=self.evhub_namespace,
             eventhub_name=self.evhub_name,
             credential=self.credential,
-            **cast(Any, self.transport_type),
+            **self.client_kwargs,
         )
 
     @property
@@ -211,6 +216,11 @@ class ManagedAzureEventhubProducer(connection_pooling.AbstractorConnector):
       credential_factory:
         A callable that returns an async ``DefaultAzureCredential``.  Mutually
         exclusive with ``connection_string``; exactly one must be supplied.
+      eventhub_transport_type:
+        Transport protocol.  Must be an ``azure.eventhub.TransportType`` instance
+        or ``None`` (default).  ``None`` omits the argument, letting the SDK
+        choose its default (AMQP).  Passed through to each pooled ``Eventhub``
+        connection.
       client_limit:
         Client limit per connection (default: 100).
       max_size:

--- a/aio_azure_clients_toolbox/clients/eventhub.py
+++ b/aio_azure_clients_toolbox/clients/eventhub.py
@@ -52,6 +52,7 @@ class Eventhub:
         "evhub_name",
         "evhub_namespace",
         "_client",
+        "transport_type",
         "client_kwargs",
     ]
 
@@ -78,6 +79,7 @@ class Eventhub:
                 stacklevel=2,
             )
             eventhub_transport_type = None
+        self.transport_type: TransportType | None = eventhub_transport_type
         self.client_kwargs: dict[str, Any] = (
             {"transport_type": eventhub_transport_type} if eventhub_transport_type is not None else {}
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aio-azure-clients-toolbox"
-version = "1.4.2"
+version = "1.4.3"
 description = "Async Azure Clients Mulligan Python projects"
 authors = [{ "name" = "Erik Aker", "email" = "eaker@mulliganfunding.com" }]
 license = { file = "LICENSE" }

--- a/tests/clients/test_eventhub.py
+++ b/tests/clients/test_eventhub.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 from aio_azure_clients_toolbox.clients import eventhub
-from azure.eventhub import EventData, EventDataBatch
+from azure.eventhub import EventData, EventDataBatch, TransportType
 from azure.eventhub.aio import EventHubProducerClient
 from azure.eventhub.exceptions import AuthenticationError, ClientClosedError, ConnectError
 
@@ -290,6 +290,28 @@ def test_bad_transport_type_warns_and_defaults_to_none(mockehub):
             eventhub_transport_type="AmqpOverWebsocket",
         )
     assert hub.client_kwargs == {}
+    assert hub.transport_type is None
+
+
+def test_explicit_none_transport_type_constructs_without_error(mockehub):
+    hub = eventhub.Eventhub(
+        "namespace_url.example.net",
+        "name",
+        mock.AsyncMock(),
+        eventhub_transport_type=None,
+    )
+    assert hub.client_kwargs == {}
+
+
+def test_valid_transport_type_sets_client_kwargs(mockehub):
+    hub = eventhub.Eventhub(
+        "namespace_url.example.net",
+        "name",
+        mock.AsyncMock(),
+        eventhub_transport_type=TransportType.AmqpOverWebsocket,
+    )
+    assert hub.transport_type is TransportType.AmqpOverWebsocket
+    assert hub.client_kwargs == {"transport_type": TransportType.AmqpOverWebsocket}
 
 
 def test_eventhub_neither_credential_nor_connection_string():

--- a/tests/clients/test_eventhub.py
+++ b/tests/clients/test_eventhub.py
@@ -289,7 +289,7 @@ def test_bad_transport_type_warns_and_defaults_to_none(mockehub):
             mock.AsyncMock(),
             eventhub_transport_type="AmqpOverWebsocket",
         )
-    assert hub.transport_type is None
+    assert hub.client_kwargs == {}
 
 
 def test_eventhub_neither_credential_nor_connection_string():

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "aio-azure-clients-toolbox"
-version = "1.4.2"
+version = "1.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
On the last commit we stored `self.transport_type = eventhub_transport_type` and then we spread it when creating EventhubProducerClietns with `**cast(Any, self.transport_type)`. However, None is not a mapping, so this crashed for every caller that didn't pass a transport type.